### PR TITLE
Add php and composer to the devcontainer.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
   "features": {
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/php:1": {
-      "version": "latest",
+      "version": "8.4",
       "installComposer": true
     },
     "ghcr.io/devcontainers/features/github-cli:1": {


### PR DESCRIPTION
While we don't yet allow running full local environments inside container having php and composer installed inside the devcontainer enables developers (and agents) to run e.g. composer and php based code quality and testing tools. 