### PR TITLE
Enable git integration in VSCode when running in devcontainer.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,7 +39,7 @@
         "redhat.vscode-yaml"
       ],
       "settings": {
-        "git.enabled": false,
+        "git.enabled": true,
         "workbench.activityBar.visible": true,
         "terminal.integrated.defaultProfile.linux": "zsh",
         "github.copilot.enable": {


### PR DESCRIPTION
Git integration should be enabled by default as this only affects local git operations.