### PR TITLE
Fix Copilot CLI MCP config never generated

### DIFF
--- a/commands/host/set-up
+++ b/commands/host/set-up
@@ -183,7 +183,7 @@ echo "✅ VS Code MCP gallery config pre-populated (wdrmcp@${WDRMCP_VERSION})"
 # ==============================================================================
 # Generate Copilot CLI MCP config
 # ==============================================================================
-if [ -f "$PROJECT_ROOT/.agents/mcp.json" ]; then
+if [ -d "$PROJECT_ROOT/.agents/tools-config" ]; then
     docker exec -i -u vscode "$AGENTS_CONTAINER" bash -c 'mkdir -p ~/.copilot && cat > ~/.copilot/mcp-config.json' <<MCPCONFIG
 {
   "mcpServers": {


### PR DESCRIPTION
## Summary

- Fix dead file check that prevented Copilot CLI MCP config from being generated
- Replace `[ -f .agents/mcp.json ]` with `[ -d .agents/tools-config ]`

Closes #16

## Test plan

- [ ] Run `ddev add-on get` and `ddev restart` on a target project
- [ ] Verify `~/.copilot/mcp-config.json` exists inside the agents container
- [ ] Verify `gh copilot` can use wdrmcp tools