### PR TITLE
fix(SSH): Use container config for DDEV user detection

### DIFF
--- a/commands/host/set-up
+++ b/commands/host/set-up
@@ -102,8 +102,9 @@ echo "🔐 Setting up SSH connectivity between agents and web containers..."
 if ! docker ps --format '{{.Names}}' | grep -q "^${WEB_CONTAINER}$"; then
     echo "⚠️  Web container not running, skipping SSH setup."
 else
-    # Detect DDEV user from web container
-    DDEV_USER=$(docker exec "$WEB_CONTAINER" stat -c '%U' /var/www/html 2>/dev/null || echo "")
+    # Detect DDEV user from the container's configured UID (set by DDEV in docker-compose)
+    CONTAINER_UID=$(docker inspect --format '{{.Config.User}}' "$WEB_CONTAINER" 2>/dev/null | cut -d: -f1)
+    DDEV_USER=$(docker exec "$WEB_CONTAINER" getent passwd "$CONTAINER_UID" 2>/dev/null | cut -d: -f1)
     if [ -z "$DDEV_USER" ]; then
         echo "⚠️  Could not detect DDEV user, skipping SSH setup."
     else


### PR DESCRIPTION
## Summary
- Replace `stat -c '%U' /var/www/html` with `docker inspect` + `getent passwd` for detecting the DDEV user during SSH setup

## Problem
The `set-up` script detected the DDEV user by checking filesystem ownership of `/var/www/html`. This fails when the project uses `performance_mode: none` (native Docker bind mounts) - the mount point can appear as `root` inside the container depending on the host OS and Docker file sharing driver.

Observed on a project with `performance_mode: none` in `.ddev/config.yaml` where the colleague got `Detected DDEV user: ""` or `root`, breaking the SSH key distribution between agents and web containers.

## Fix
Read the container's configured UID from `docker inspect --format '{{.Config.User}}'` (set by DDEV in the generated docker-compose) and resolve it to a username via `getent passwd`. This is independent of volume mount semantics.

## Test plan
- [ ] `ddev start` on a project with `performance_mode: none`
- [ ] `ddev start` on a project with default performance mode (Mutagen)
- [ ] Verify `Detected DDEV user:` shows the correct username in both cases
- [ ] Verify SSH connectivity (agents -> web) works after setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the user detection mechanism within the web container to improve reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->