### PR TITLE
Set terminal locale in ddev set-up

### DIFF
--- a/commands/host/set-up
+++ b/commands/host/set-up
@@ -10,6 +10,8 @@ set -e
 PROJECT_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 cd "$PROJECT_ROOT"
 
+PROJECT_LOCALE="en_US.utf8"
+
 # Determine project name
 if [ -z "$DDEV_PROJECT" ]; then
     DDEV_PROJECT=$(ddev describe -j 2>/dev/null | jq -r '.raw.name' 2>/dev/null || echo "ddev-agents")
@@ -156,6 +158,15 @@ SSHCONFIG
             grep -q 'export DDEV_SSH_USER=' ~/.zshrc 2>/dev/null || echo 'export DDEV_SSH_USER=$DDEV_USER' >> ~/.zshrc
         "
         echo "✅ DDEV_SSH_USER=$DDEV_USER set in agents container shell configs"
+
+        # Set locale in agents container for MCP tool configs
+        docker exec -i -u vscode "$AGENTS_CONTAINER" bash -c "
+            grep -q 'export LANG=' ~/.bashrc 2>/dev/null || echo 'export LANG=$PROJECT_LOCALE' >> ~/.bashrc
+            grep -q 'export LANG=' ~/.zshrc 2>/dev/null || echo 'export LANG=$PROJECT_LOCALE' >> ~/.zshrc
+            grep -q 'export LC_ALL=' ~/.bashrc 2>/dev/null || echo 'export LC_ALL=$PROJECT_LOCALE' >> ~/.bashrc
+            grep -q 'export LC_ALL=' ~/.zshrc 2>/dev/null || echo 'export LC_ALL=$PROJECT_LOCALE' >> ~/.zshrc
+        "
+        echo "✅ LANG=$PROJECT_LOCALE, LC_ALL=$PROJECT_LOCALE set in agents container shell configs"
 
         # Clean up temp keypair from host
         rm -rf "$SSH_TMPDIR"


### PR DESCRIPTION
The default locale within the agents container is currently `POSIX`, which makes using the terminal a bit awkward (arrow keys don't work, line drawing characters aren't used, etc).

This PR changes the terminal locale to `en_US.utf8`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added locale environment configuration during development environment initialization to ensure consistent locale settings across containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->