### PR TITLE
Tools for grumphp, phpunit, npm

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -13,6 +13,7 @@ An MCP server that gives AI agents tools to run commands in DDEV containers via 
 ## How to Use
 
 1. **Installation:**
+
    ```bash
    cd /path/to/ddev-project
    ddev get wunderio/ddev-agents
@@ -101,6 +102,7 @@ This file is preserved across addon reinstalls (non-destructive merge).
 ## Available Tool Types
 
 - `command` – Run shell commands with parameter substitution
+- `check` – Run checks and tests with parameter substitution
 - `mcp_server` – Proxy to additional MCP servers
 
 ### Command Tool Type
@@ -118,6 +120,45 @@ tools:
     command_template: "my_command {name} {args}"
     ssh_target: "web"
     working_dir: "/var/www/html"
+    default_args:
+      args: []
+
+    input_schema:
+      type: object
+      properties:
+        name:
+          type: string
+          description: "Name argument"
+        args:
+          type: array
+          items:
+            type: string
+          description: "Flags and options as separate array elements"
+      required:
+        - name
+```
+
+### Check Tool Type
+
+Check tools execute shell commands like the Command tools (above), but provide
+proper feedback to agents when the checks or tests being run use non-zero
+exit codes to signal that the checks/tests did not pass.
+
+Example:
+
+```yaml
+tools:
+  - name: my_tests_tool
+    type: check
+    enabled: true
+    description: "Run my custom tests"
+    command_template: "my_custom_tests {name} {args}"
+    ssh_target: "web"
+    working_dir: "/var/www/html"
+    # Set to true if you need to bootstrap Drupal (for e.g. drush).
+    use_env_vars_in_remote: false
+    # Exit codes to interpret as the command succeeding, but the checks failing.
+    success_exit_codes: [1, 2]
     default_args:
       args: []
 

--- a/.agents/tools-config/grumphp.yml
+++ b/.agents/tools-config/grumphp.yml
@@ -23,7 +23,7 @@ tools:
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
-    timeout: 120_000 # ms
+    timeout: 120 # seconds
     use_env_vars_in_remote: false
     # Consider exit code 1 as the command succeeding,
     # but report it as "checks failed".
@@ -43,7 +43,7 @@ tools:
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
-    timeout: 60_000 # ms
+    timeout: 60 # seconds
     use_env_vars_in_remote: false
     default_args:
       tasks: ["php_compatibility"]
@@ -61,7 +61,7 @@ tools:
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
-    timeout: 60_000 # ms
+    timeout: 60 # seconds
     use_env_vars_in_remote: false
     default_args:
       tasks: ["php_check_syntax"]
@@ -79,7 +79,7 @@ tools:
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
-    timeout: 60_000 # ms
+    timeout: 60 # seconds
     use_env_vars_in_remote: false
     default_args:
       tasks: ["phpcs"]
@@ -97,7 +97,7 @@ tools:
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
-    timeout: 60_000 # ms
+    timeout: 60 # seconds
     use_env_vars_in_remote: false
     default_args:
       tasks: ["php_stan"]
@@ -115,7 +115,7 @@ tools:
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
-    timeout: 60_000 # ms
+    timeout: 60 # seconds
     use_env_vars_in_remote: false
     default_args:
       tasks: ["yaml_lint"]
@@ -133,7 +133,7 @@ tools:
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
-    timeout: 60_000 # ms
+    timeout: 60 # seconds
     use_env_vars_in_remote: false
     default_args:
       tasks: ["json_lint"]

--- a/.agents/tools-config/grumphp.yml
+++ b/.agents/tools-config/grumphp.yml
@@ -29,6 +29,9 @@ tools:
     # but report it as "checks failed".
     # Note that the default value is [1].
     # success_exit_codes: [1]
+    input_schema:
+      type: object
+      properties: {}
 
   - name: grumphp_check_php_compatibility
     enabled: true
@@ -44,6 +47,9 @@ tools:
     use_env_vars_in_remote: false
     default_args:
       tasks: ["php_compatibility"]
+    input_schema:
+      type: object
+      properties: {}
 
   - name: grumphp_check_php_syntax
     enabled: true
@@ -59,6 +65,9 @@ tools:
     use_env_vars_in_remote: false
     default_args:
       tasks: ["php_check_syntax"]
+    input_schema:
+      type: object
+      properties: {}
 
   - name: grumphp_check_phpcs
     enabled: true
@@ -74,6 +83,9 @@ tools:
     use_env_vars_in_remote: false
     default_args:
       tasks: ["phpcs"]
+    input_schema:
+      type: object
+      properties: {}
 
   - name: grumphp_check_phpstan
     enabled: true
@@ -89,6 +101,9 @@ tools:
     use_env_vars_in_remote: false
     default_args:
       tasks: ["php_stan"]
+    input_schema:
+      type: object
+      properties: {}
 
   - name: grumphp_lint_yaml
     enabled: true
@@ -104,6 +119,9 @@ tools:
     use_env_vars_in_remote: false
     default_args:
       tasks: ["yaml_lint"]
+    input_schema:
+      type: object
+      properties: {}
 
   - name: grumphp_lint_json
     enabled: true
@@ -119,3 +137,6 @@ tools:
     use_env_vars_in_remote: false
     default_args:
       tasks: ["json_lint"]
+    input_schema:
+      type: object
+      properties: {}

--- a/.agents/tools-config/grumphp.yml
+++ b/.agents/tools-config/grumphp.yml
@@ -1,0 +1,121 @@
+# Validation - GrumPHP
+#
+# - PHP compatibility
+# - Check syntax
+# - PHPCS
+# - PHPstan
+# - yaml_lint
+# - json_lint
+
+tools:
+  - name: grumphp_run
+    enabled: true
+    description: |
+      Run all GrumPHP checks on the entire codebase.
+
+    # Note the type of this tool: test runners like grumphp may exit
+    # with a non-zero exit code if the command succeeds but checks/tests fail;
+    # the "check" executor will report the passed/failed status to agents.
+    #
+    # See: success_exit_codes
+    type: check
+    command_template: "./vendor/bin/grumphp run --no-ansi --no-interaction"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 120_000 # ms
+    use_env_vars_in_remote: false
+    # Consider exit code 1 as the command succeeding,
+    # but report it as "checks failed".
+    # Note that the default value is [1].
+    # success_exit_codes: [1]
+
+  - name: grumphp_check_php_compatibility
+    enabled: true
+    description: |
+      Run PHP compatibility checks on the entire codebase.
+
+    type: check
+    command_template: "./vendor/bin/grumphp run --tasks {tasks} --no-ansi --no-interaction"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 60_000 # ms
+    use_env_vars_in_remote: false
+    default_args:
+      tasks: ["php_compatibility"]
+
+  - name: grumphp_check_php_syntax
+    enabled: true
+    description: |
+      Run PHP syntax checking on the entire codebase.
+
+    type: check
+    command_template: "./vendor/bin/grumphp run --tasks {tasks} --no-ansi --no-interaction"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 60_000 # ms
+    use_env_vars_in_remote: false
+    default_args:
+      tasks: ["php_check_syntax"]
+
+  - name: grumphp_check_phpcs
+    enabled: true
+    description: |
+      Run PHPCS checks on the entire codebase.
+
+    type: check
+    command_template: "./vendor/bin/grumphp run --tasks {tasks} --no-ansi --no-interaction"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 60_000 # ms
+    use_env_vars_in_remote: false
+    default_args:
+      tasks: ["phpcs"]
+
+  - name: grumphp_check_phpstan
+    enabled: true
+    description: |
+      Run PHPStan checks on the entire codebase.
+
+    type: check
+    command_template: "./vendor/bin/grumphp run --tasks {tasks} --no-ansi --no-interaction"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 60_000 # ms
+    use_env_vars_in_remote: false
+    default_args:
+      tasks: ["php_stan"]
+
+  - name: grumphp_lint_yaml
+    enabled: true
+    description: |
+      Run YAML linting on the entire codebase.
+
+    type: check
+    command_template: "./vendor/bin/grumphp run --tasks {tasks} --no-ansi --no-interaction"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 60_000 # ms
+    use_env_vars_in_remote: false
+    default_args:
+      tasks: ["yaml_lint"]
+
+  - name: grumphp_lint_json
+    enabled: true
+    description: |
+      Run JSON linting on the entire codebase.
+
+    type: check
+    command_template: "./vendor/bin/grumphp run --tasks {tasks} --no-ansi --no-interaction"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 60_000 # ms
+    use_env_vars_in_remote: false
+    default_args:
+      tasks: ["json_lint"]

--- a/.agents/tools-config/npm.yml
+++ b/.agents/tools-config/npm.yml
@@ -1,0 +1,37 @@
+# npm-related tools
+#
+# NOTE: These are examples and probably need to be adapted to every project.
+
+tools:
+  - name: npm_run_build
+    enabled: true
+    description: |
+      Build the frontend application.
+
+    type: command
+    command_template: "npm {args}"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 10_000 # ms
+    use_env_vars_in_remote: false
+    default_args:
+      args: ["run", "build"]
+
+  - name: npm_run_test
+    enabled: true
+    description: |
+      Run tests defined in the project's package.json.
+
+    type: check
+    command_template: "npm {args}"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 10_000 # ms
+    # Consider both exit codes 1 and 2 as the command succeeding,
+    # but report them as "checks failed".
+    success_exit_codes: [1, 2]
+    use_env_vars_in_remote: false
+    default_args:
+      args: ["run", "test"]

--- a/.agents/tools-config/npm.yml
+++ b/.agents/tools-config/npm.yml
@@ -9,14 +9,16 @@ tools:
       Build the frontend application.
 
     type: command
-    command_template: "npm {args}"
+    command_template: "npm run build"
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
     timeout: 10_000 # ms
     use_env_vars_in_remote: false
-    default_args:
-      args: ["run", "build"]
+    default_args: {}
+    input_schema:
+      type: object
+      properties: {}
 
   - name: npm_run_test
     enabled: true
@@ -24,7 +26,7 @@ tools:
       Run tests defined in the project's package.json.
 
     type: check
-    command_template: "npm {args}"
+    command_template: "npm run test"
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
@@ -33,5 +35,7 @@ tools:
     # but report them as "checks failed".
     success_exit_codes: [1, 2]
     use_env_vars_in_remote: false
-    default_args:
-      args: ["run", "test"]
+    default_args: {}
+    input_schema:
+      type: object
+      properties: {}

--- a/.agents/tools-config/npm.yml
+++ b/.agents/tools-config/npm.yml
@@ -13,7 +13,7 @@ tools:
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
-    timeout: 10_000 # ms
+    timeout: 10 # seconds
     use_env_vars_in_remote: false
     default_args: {}
     input_schema:
@@ -30,7 +30,7 @@ tools:
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
-    timeout: 10_000 # ms
+    timeout: 10 # seconds
     # Consider both exit codes 1 and 2 as the command succeeding,
     # but report them as "checks failed".
     success_exit_codes: [1, 2]

--- a/.agents/tools-config/phpunit.yml
+++ b/.agents/tools-config/phpunit.yml
@@ -11,6 +11,9 @@ tools:
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
+    input_schema:
+      type: object
+      properties: {}
 
   - name: phpunit_list_all_test_files
     enabled: true
@@ -22,6 +25,9 @@ tools:
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
+    input_schema:
+      type: object
+      properties: {}
 
   - name: phpunit_run_all_tests
     enabled: true
@@ -33,6 +39,9 @@ tools:
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
+    input_schema:
+      type: object
+      properties: {}
 
   - name: phpunit_run_test_suites
     enabled: true

--- a/.agents/tools-config/phpunit.yml
+++ b/.agents/tools-config/phpunit.yml
@@ -36,6 +36,7 @@ tools:
 
     type: check
     command_template: "./vendor/bin/phpunit --configuration phpunit.xml"
+    success_exit_codes: [1, 2]
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
@@ -51,6 +52,7 @@ tools:
 
     type: check
     command_template: "./vendor/bin/phpunit --configuration phpunit.xml --no-progress --testsuite {names}"
+    success_exit_codes: [1, 2]
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"
@@ -72,6 +74,7 @@ tools:
 
     type: check
     command_template: "./vendor/bin/phpunit --configuration phpunit.xml --no-progress {files}"
+    success_exit_codes: [1, 2]
     ssh_target: "web"
     ssh_user: "${DDEV_SSH_USER}"
     working_dir: "/var/www/html"

--- a/.agents/tools-config/phpunit.yml
+++ b/.agents/tools-config/phpunit.yml
@@ -50,11 +50,9 @@ tools:
       type: object
       properties:
         names:
-          type: array
-          items:
-            type: string
+          type: string
           description: >
-            Names of test suites to run.
+            Name of the test suite to run, or a comma-separated list of test suite names.
       required:
         - names
 

--- a/.agents/tools-config/phpunit.yml
+++ b/.agents/tools-config/phpunit.yml
@@ -1,0 +1,82 @@
+# PHPUnit tests.
+
+tools:
+  - name: phpunit_list_all_test_suites
+    enabled: true
+    description: |
+      Lists all available test suites.
+
+    type: command
+    command_template: "./vendor/bin/phpunit --configuration phpunit.xml --list-suites"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+
+  - name: phpunit_list_all_test_files
+    enabled: true
+    description: |
+      Lists all available test files.
+
+    type: command
+    command_template: "./vendor/bin/phpunit --configuration phpunit.xml --list-test-files"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+
+  - name: phpunit_run_all_tests
+    enabled: true
+    description: |
+      Run all tests using PHPUnit.
+
+    type: check
+    command_template: "./vendor/bin/phpunit --configuration phpunit.xml"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+
+  - name: phpunit_run_test_suites
+    enabled: true
+    description: |
+      Run specific test suites using PHPUnit.
+      Use phpunit_list_all_test_suites to discover the names of test suites.
+
+    type: check
+    command_template: "./vendor/bin/phpunit --configuration phpunit.xml --no-progress --testsuite {names}"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+
+    input_schema:
+      type: object
+      properties:
+        names:
+          type: array
+          items:
+            type: string
+          description: >
+            Names of test suites to run.
+      required:
+        - names
+
+  - name: phpunit_run_test_files
+    enabled: true
+    description: |
+      Run specific unit test files using PHPUnit.
+
+    type: check
+    command_template: "./vendor/bin/phpunit --configuration phpunit.xml --no-progress {files}"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+
+    input_schema:
+      type: object
+      properties:
+        files:
+          type: array
+          items:
+            type: string
+          description: >
+            Paths to unit tests files to run.
+      required:
+        - files

--- a/.agents/tools-config/phpunit.yml
+++ b/.agents/tools-config/phpunit.yml
@@ -84,6 +84,6 @@ tools:
           items:
             type: string
           description: >
-            Paths to unit tests files to run.
+            Paths to unit test files to run.
       required:
         - files


### PR DESCRIPTION
## Changes

- Add tools for running grumphp checks, phpunit tests and and npm scripts
- Add documentation for the upcoming `check` tool executor type

## Testing

Requires `wdrmcp` from https://github.com/wunderio/wdrmcp/pull/14 – **Do not merge this before it gets released!**

Ask the agent to run e.g. all `grumphp_*`, `phpunit_*`, `npm_*` tools as a smoke test, and to ignore all output unless it contains errors related to tool execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added agent tools for code-quality validation: GrumPHP checks, npm build/test, and PHPUnit test runners.
  - Support running all tests, specific suites, or individual test files from agents.
  - Introduced a "check" tool type that treats configurable exit codes as test/check failures.

* **Documentation**
  - Added docs and examples for the new "check" tool type and agent tool configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->