### PR TITLE
Fix Copilot CLI "blocked by policy" warning for MCP servers

### DIFF
--- a/commands/host/set-up
+++ b/commands/host/set-up
@@ -263,23 +263,42 @@ echo "✅ ~/.copilot symlinked to /workspace/.copilot"
 # Generate Copilot CLI MCP config
 # ==============================================================================
 if [ -d "$PROJECT_ROOT/.agents/tools-config" ]; then
+    # Each server's local config is hashed into a fingerprint and matched
+    # against the registry's fingerprint for that server. The CLI infers the
+    # fingerprint from `command` + `args` (must surface the npm package id) or
+    # from a `type: "http"` URL — anything wrapping the call (e.g. bash -c)
+    # makes the fingerprint uncomputable and the server is blocked under
+    # "Registry only" policy. Each entry below mirrors the shape used in the
+    # registry at https://mcp.wdr.io so fingerprints match.
     docker exec -i -u vscode "$AGENTS_CONTAINER" bash -c 'cat > ~/.copilot/mcp-config.json' <<MCPCONFIG
 {
   "mcpServers": {
     "wdrmcp": {
-      "command": "bash",
+      "type": "stdio",
+      "command": "npx",
       "args": [
-        "-c",
-        "set -a; export DDEV_SSH_USER=${DDEV_USER:-}; [ -f /workspace/.env ] && source /workspace/.env; exec npx -y @wunderio/wdrmcp --tools-config /workspace/.agents/tools-config"
+        "-y",
+        "@wunderio/wdrmcp",
+        "--tools-config",
+        "/workspace/.agents/tools-config"
       ],
+      "env": {
+        "DDEV_SSH_USER": "${DDEV_USER:-}"
+      },
       "tools": ["*"]
     },
     "wunder-quality-system": {
-      "type": "http",
-      "url": "https://quality.wunder.io/mcp",
-      "headers": {
-        "Authorization": "Bearer \${WQS_MCP_API_KEY}"
-      }
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "supergateway",
+        "--streamableHttp",
+        "https://quality.wunder.io/mcp",
+        "--oauth2Bearer",
+        "\${WQS_MCP_API_KEY}"
+      ],
+      "tools": ["*"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Under the org's **Registry only** MCP policy, `ddev copilot` started warning:

```
! 2 MCP servers were blocked by policy: 'wdrmcp', 'wunder-quality-system'
```

Root cause is in **how Copilot CLI matches local servers to the registry**: it computes a fingerprint from `command` + `args` (must surface the npm package identifier) or from a `type: "http"` URL, and compares to the registry entry's fingerprint. The previous CLI config:

- Wrapped wdrmcp in `bash -c "set -a; export DDEV_SSH_USER=…; [ -f /workspace/.env ] && source /workspace/.env; exec npx -y @wunderio/wdrmcp …"` → fingerprinter sees `command: bash` and can't extract the npm package → identity `(none)` → blocked.
- Used `type: "http"` for wunder-quality-system → fingerprint based on URL + header names → didn't match the registry entry's stdio + supergateway fingerprint → blocked.

The name has no bearing on matching; that was a red herring during diagnosis.

This change rewrites the generated `~/.copilot/mcp-config.json` so both entries fingerprint-match `mcp.wdr.io`:

- **wdrmcp**: bare `npx`, `DDEV_SSH_USER` moved into the mcp `env` field (resolved at set-up time from `$DDEV_USER`).
- **wunder-quality-system**: stdio + supergateway, mirroring the VS Code `mcp.json` block above it and the registry entry.

## Behaviour change

The old bash wrapper also did `[ -f /workspace/.env ] && source /workspace/.env` on every wdrmcp launch. That is dropped. Verified against [wdrmcp `src/config.ts`](https://github.com/wunderio/wdrmcp/blob/main/src/config.ts) that wdrmcp reads only:

| Var | How supplied after this change |
|---|---|
| `DDEV_SSH_USER` | mcp `env` field (this PR) |
| `DDEV_PROJECT` | docker-compose `environment:` (unchanged) |
| `SSH_STRICT_HOST_KEY_CHECKING` / `DDEV_SSH_TARGET` / `DDEV_SSH_USER_FILE` / `HOST_PROJECT_ROOT` / `CONTAINER_PROJECT_ROOT` | optional, safe defaults |

So nothing wdrmcp-relevant ever flowed through `/workspace/.env`. Projects that put unrelated keys there for their own scripts are unaffected (the load only ever happened inside the wdrmcp launcher subshell, never broader).

## Verification

Applied the new config shape live in the drupal-project agents container and ran `copilot --log-level debug`. Both fingerprints now match:

```
Server "wdrmcp"                local fingerprint: e12f71fa…  registry: e12f71fa…  → matched — allowing
Server "wunder-quality-system" local fingerprint: e0e12066…  registry: e0e12066…  → matched — allowing
```

The `! N MCP servers were blocked by policy` warning is gone and WQS tools load successfully in-session.

## Test plan

- [ ] In a project with this branch installed via `ddev addon get`, run `ddev restart` then `ddev copilot`
- [ ] Confirm no `! MCP servers were blocked by policy` warning
- [ ] Confirm wdrmcp tools work (e.g. an SSH-bridged drush call)
- [ ] Confirm wunder-quality-system tools work (e.g. `list_pages` or `search_docs`)
- [ ] Optional: with `copilot --log-level debug --log-dir /tmp/cplog -p "exit" --allow-all-tools`, grep `fingerprint matched` for both servers in the produced log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined Copilot CLI MCP server configuration generation for improved clarity and easier maintenance
  * Updated MCP server authentication mechanism to provide better security and consistency
  * Enhanced environment variable handling in the development setup process
  * Updated documentation to reflect new configuration standards

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wunderio/ddev-agents/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->