### PR TITLE
Add npm package to support node based projects.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify DDEV add-on sync
+        run: npm run sync-core-to-ddev
+
+      - name: Run tests
+        run: npm test
+
+      - name: Verify agents CLI help
+        run: node packages/npm-cli/bin/agents --help

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish npm packages
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Publish workspaces
+        run: npm publish --workspaces --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.copilot/
+.copilot
+node_modules/
+.ddev/
+*.log
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `@wunderio/node-agents` npm package for node/npm projects without DDEV.
+- Shared `@wunderio/agents-core` package containing devcontainer templates,
+  managed security config, MCP config templates, version resolution, and
+  Copilot invocation helpers.
+- npm-family MCP tools (`node_install`, `node_ci`, `node_run`, `node_run_build`,
+  `node_run_test`, `node_run_lint`, `npx`, `node_logs`) with lockfile-based
+  package-manager detection (npm/yarn/pnpm).
+- CLI commands: `agents build`, `agents set-up`, `agents copilot`, `agents start`,
+  `agents stop`, `agents npm`, `agents npx`, `agents exec`.
+- Monorepo workspaces (`packages/core`, `packages/npm-cli`) alongside the
+  existing DDEV add-on files at the repository root.
+- Build-time sync script (`npm run sync-core-to-ddev`) to regenerate DDEV
+  add-on devcontainer configs and managed config from shared core templates.
+
+### Changed
+
+- Converted repository to npm workspaces with a root `package.json`.
+- Updated README with node/npm flavour documentation.
+
 ## [1.1.2] - 2026-03-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Standardized environment for creating an isolated workspace where agentic AI tools can be run safely and consistently across Wunder.io projects.
 
+## Flavours
+
+This repository provides the agents environment in two flavours:
+
+1.  **DDEV add-on** (`ddev-agents`) — for PHP/Drupal projects that already use
+    DDEV. Installed with `ddev addon get wunderio/ddev-agents`.
+2.  **npm package** (`@wunderio/node-agents`) — for node/npm projects that do
+    not use DDEV. Installed with `npm i -D @wunderio/node-agents`.
+
+Both share the same security model, Copilot CLI support, WQS MCP integration,
+and tool configuration patterns. The npm flavour runs its own isolated
+container via the devcontainer CLI instead of DDEV.
+
 ## Overview
 
 The `ddev-agents` add-on provides a pre-configured `agents` service and VS Code Dev Container settings. Key benefits include:
@@ -135,6 +148,57 @@ The `.agents/tools-config/` directory contains YAML definitions for tools expose
 -   **Drupal MCP**: Proxy to Drupal's built-in MCP server endpoint
 
 See `.agents/README.md` for details on adding custom tools and configuring credentials.
+
+## Node/npm Projects
+
+For projects that are not PHP/Drupal and do not use DDEV, install the standalone
+npm package:
+
+```bash
+npm install --save-dev @wunderio/node-agents
+```
+
+Add convenience scripts to `package.json`:
+
+```json
+{
+  "scripts": {
+    "agents:build": "agents build",
+    "agents:setup": "agents set-up",
+    "copilot": "agents copilot"
+  }
+}
+```
+
+Run setup once:
+
+```bash
+npx agents set-up
+```
+
+Then run Copilot:
+
+```bash
+npx agents copilot
+npx agents copilot -p "explain this function"
+```
+
+Other useful passthrough commands:
+
+```bash
+npx agents npm install
+npx agents npm run build
+npx agents npm run test
+npx agents npx eslint .
+npx agents exec -- node -v
+```
+
+The npm flavour uses the same devcontainer isolation, managed security config,
+WQS MCP, and Copilot CLI authentication as the DDEV add-on. MCP tools execute
+inside the agents container (there is no separate DDEV web container), and the
+package manager is auto-detected from the project's lockfile.
+
+See `packages/npm-cli/README.md` for full documentation.
 
 ## GitHub Copilot CLI
 

--- a/mcp/.vscode/extensions.json
+++ b/mcp/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"DavidAnson.vscode-markdownlint"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}

--- a/mcp/.vscode/mcp.json
+++ b/mcp/.vscode/mcp.json
@@ -1,0 +1,24 @@
+{
+	"servers": {
+		"wdrmcp": {
+			"type": "stdio",
+			"command": "npx",
+			"args": [
+				"-y",
+				"@wunderio/wdrmcp@0.1.17",
+				"--tools-config",
+				"/workspace/.agents/tools-config"
+			],
+			"gallery": "https://mcp.wdr.io",
+			"version": "0.1.17"
+		},
+		"wunder-quality-system": {
+			"type": "http",
+			"url": "https://quality.wunder.io/mcp",
+			"headers": {
+				"Authorization": "Bearer ${WQS_MCP_API_KEY}"
+			}
+		}
+	},
+	"inputs": []
+}

--- a/mcp/.vscode/settings.json
+++ b/mcp/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "[markdown]": {
+    "editor.tabSize": 4,
+    "editor.insertSpaces": true
+  },
+  "markdown.validate.enabled": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,66 @@
+{
+  "name": "@wunderio/ddev-agents-monorepo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@wunderio/ddev-agents-monorepo",
+      "version": "1.0.0",
+      "workspaces": [
+        "packages/*"
+      ],
+      "devDependencies": {
+        "@types/node": "^22.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wunderio/agents-core": {
+      "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@wunderio/node-agents": {
+      "resolved": "packages/npm-cli",
+      "link": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/core": {
+      "name": "@wunderio/agents-core",
+      "version": "1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/npm-cli": {
+      "name": "@wunderio/node-agents",
+      "version": "1.0.0",
+      "dependencies": {
+        "@wunderio/agents-core": "^1.0.0"
+      },
+      "bin": {
+        "agents": "bin/agents"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@wunderio/ddev-agents-monorepo",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Monorepo for Wunder.io agentic AI environments: DDEV add-on and standalone npm CLI.",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "npm run build --workspaces",
+    "test": "npm test --workspaces",
+    "lint": "npm run lint --workspaces",
+    "sync-core-to-ddev": "node scripts/sync-core-to-ddev.js"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@wunderio/agents-core",
+  "version": "1.0.0",
+  "description": "Shared core for Wunder.io agentic AI environments.",
+  "main": "src/index.js",
+  "type": "module",
+  "files": [
+    "src/",
+    "templates/"
+  ],
+  "scripts": {
+    "test": "node --test src/**/*.test.js"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,0 +1,26 @@
+/**
+ * Shared core for Wunder.io agentic AI environments.
+ *
+ * Used by:
+ *   - @wunderio/node-agents (npm CLI for non-DDEV node projects)
+ *   - the DDEV add-on in this repo (via build-time sync)
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+
+function loadTemplate(name) {
+  return readFileSync(join(rootDir, 'templates', name), 'utf8');
+}
+
+export const managedConfig = JSON.parse(loadTemplate('copilot-managed-config.json'));
+export const devcontainerFeatures = JSON.parse(loadTemplate('devcontainer-features.json'));
+export const mcpConfigTemplate = loadTemplate('mcp-config.json.hbs');
+export const vscodeMcpTemplate = loadTemplate('vscode-mcp.json.hbs');
+
+export { resolveNodeVersion } from './lib/version-resolver.js';
+export { invokeCopilot } from './lib/copilot-invoker.js';

--- a/packages/core/src/lib/copilot-invoker.js
+++ b/packages/core/src/lib/copilot-invoker.js
@@ -1,0 +1,43 @@
+/**
+ * Build the command to invoke GitHub Copilot CLI inside a devcontainer.
+ *
+ * Uses `devcontainer exec` so that remoteEnv from devcontainer.json is injected
+ * (GH_TOKEN, WQS_MCP_API_KEY) without storing secrets in the container image.
+ */
+
+export function buildCopilotCommand({ workspaceFolder, args = [] } = {}) {
+  const command = ['devcontainer', 'exec', '--workspace-folder', workspaceFolder];
+
+  if (args.length === 0) {
+    command.push('gh', 'copilot');
+  } else {
+    command.push('gh', 'copilot', ...args);
+  }
+
+  return command;
+}
+
+export async function invokeCopilot({ workspaceFolder, args = [], spawnOptions = {} } = {}) {
+  const { spawn } = await import('node:child_process');
+  const command = buildCopilotCommand({ workspaceFolder, args });
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command[0], command.slice(1), {
+      stdio: 'inherit',
+      ...spawnOptions,
+      env: { ...process.env, ...spawnOptions.env }
+    });
+
+    child.on('close', (code) => {
+      if (code === 0 || code === null) {
+        resolve(code ?? 0);
+      } else {
+        const err = new Error(`Copilot exited with code ${code}`);
+        err.exitCode = code;
+        reject(err);
+      }
+    });
+
+    child.on('error', reject);
+  });
+}

--- a/packages/core/src/lib/version-resolver.js
+++ b/packages/core/src/lib/version-resolver.js
@@ -1,0 +1,51 @@
+/**
+ * Resolve the Node.js version for the agents devcontainer.
+ *
+ * Priority:
+ *   1. explicit override (e.g. CLI --node-version)
+ *   2. .nvmrc in project root
+ *   3. package.json engines.node
+ *   4. fallback default LTS
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DEFAULT_NODE_VERSION = '22';
+
+function parseEnginesNode(range) {
+  if (!range) return null;
+  // Handle common forms: "22", "22.x", ">=20", "^20.0.0", "20 || 22"
+  const match = String(range).match(/(\d+)/);
+  return match ? match[1] : null;
+}
+
+export function resolveNodeVersion({ projectRoot, explicitVersion = null } = {}) {
+  if (explicitVersion) {
+    return String(explicitVersion).trim();
+  }
+
+  const nvmrcPath = join(projectRoot, '.nvmrc');
+  if (existsSync(nvmrcPath)) {
+    const version = readFileSync(nvmrcPath, 'utf8').trim();
+    if (version) {
+      // Strip leading 'v' if present
+      return version.replace(/^v/, '');
+    }
+  }
+
+  const packageJsonPath = join(projectRoot, 'package.json');
+  if (existsSync(packageJsonPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+      const parsed = parseEnginesNode(pkg.engines?.node);
+      if (parsed) {
+        return parsed;
+      }
+    } catch {
+      // Ignore malformed package.json
+    }
+  }
+
+  return DEFAULT_NODE_VERSION;
+}

--- a/packages/core/src/lib/version-resolver.test.js
+++ b/packages/core/src/lib/version-resolver.test.js
@@ -1,0 +1,46 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveNodeVersion } from './version-resolver.js';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function withProject(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'agents-test-'));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('resolveNodeVersion', () => {
+  it('uses explicit version first', () => {
+    withProject((dir) => {
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ engines: { node: '18.x' } }));
+      writeFileSync(join(dir, '.nvmrc'), '20');
+      assert.equal(resolveNodeVersion({ projectRoot: dir, explicitVersion: '16' }), '16');
+    });
+  });
+
+  it('falls back to .nvmrc', () => {
+    withProject((dir) => {
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ engines: { node: '18.x' } }));
+      writeFileSync(join(dir, '.nvmrc'), 'v20.5.0');
+      assert.equal(resolveNodeVersion({ projectRoot: dir }), '20.5.0');
+    });
+  });
+
+  it('falls back to package.json engines.node', () => {
+    withProject((dir) => {
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ engines: { node: '>=20.0.0' } }));
+      assert.equal(resolveNodeVersion({ projectRoot: dir }), '20');
+    });
+  });
+
+  it('uses default when nothing is present', () => {
+    withProject((dir) => {
+      assert.equal(resolveNodeVersion({ projectRoot: dir }), '22');
+    });
+  });
+});

--- a/packages/core/templates/copilot-managed-config.json
+++ b/packages/core/templates/copilot-managed-config.json
@@ -1,0 +1,33 @@
+{
+
+  "_comment": "#ddev-generated",
+  "tools": {
+    "deny": [
+      "git push*",
+      "git remote*",
+      "git checkout*",
+      "git reset --hard*",
+      "git clean -f*",
+      "git branch -D*",
+      "npm publish*",
+      "composer publish*",
+      "ssh *",
+      "rm -rf /*",
+      "sudo *"
+    ]
+  },
+  "files": {
+    "deny": [
+      ".env",
+      ".env.*",
+      "*secrets*",
+      "**/credentials*",
+      "**/*.pem",
+      "**/*.key",
+      "**/.npmrc",
+      "**/.htpasswd",
+      "wp-config.php",
+      "**/settings.local.php"
+    ]
+  }
+}

--- a/packages/core/templates/devcontainer-features.json
+++ b/packages/core/templates/devcontainer-features.json
@@ -1,0 +1,15 @@
+{
+  "ghcr.io/devcontainers/features/node:1": {
+    "version": "__NODE_VERSION__"
+  },
+  "ghcr.io/devcontainers/features/github-cli:1": {
+    "installDirectlyFromGitHubRelease": true
+  },
+  "ghcr.io/devcontainers/features/copilot-cli:1": {},
+  "ghcr.io/devcontainers/features/git:1": {},
+  "ghcr.io/devcontainers/features/common-utils:2": {
+    "installZsh": true,
+    "configureZshAsDefaultShell": true
+  },
+  "ghcr.io/devcontainers-extra/features/ripgrep:1": {}
+}

--- a/packages/core/templates/devcontainer-features.php.json
+++ b/packages/core/templates/devcontainer-features.php.json
@@ -1,0 +1,19 @@
+{
+  "ghcr.io/devcontainers/features/node:1": {
+    "version": "__NODE_VERSION__"
+  },
+  "ghcr.io/shyim/devcontainers-features/php:latest": {
+    "version": "__PHP_VERSION__",
+    "installComposer": true
+  },
+  "ghcr.io/devcontainers/features/github-cli:1": {
+    "installDirectlyFromGitHubRelease": true
+  },
+  "ghcr.io/devcontainers/features/copilot-cli:1": {},
+  "ghcr.io/devcontainers/features/git:1": {},
+  "ghcr.io/devcontainers/features/common-utils:2": {
+    "installZsh": true,
+    "configureZshAsDefaultShell": true
+  },
+  "ghcr.io/devcontainers-extra/features/ripgrep:1": {}
+}

--- a/packages/core/templates/devcontainer.build.json.php.hbs
+++ b/packages/core/templates/devcontainer.build.json.php.hbs
@@ -1,0 +1,32 @@
+{
+  "containerEnv": {
+    "GH_TOKEN": "${localEnv:DDEV_AGENTS_GH_TOKEN}",
+    "WQS_MCP_API_KEY": "${localEnv:WQS_MCP_API_KEY}"
+  },
+  "remoteEnv": {
+    "GH_TOKEN": "${localEnv:DDEV_AGENTS_GH_TOKEN}",
+    "WQS_MCP_API_KEY": "${localEnv:WQS_MCP_API_KEY}",
+    "SSH_AUTH_SOCK": ""
+  },
+  "name": "Agents: __PROJECT_NAME__ Build",
+  "image": "mcr.microsoft.com/devcontainers/python:3-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "__NODE_VERSION__"
+    },
+    "ghcr.io/shyim/devcontainers-features/php:latest": {
+      "version": "__PHP_VERSION__",
+      "installComposer": true
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "installDirectlyFromGitHubRelease": true
+    },
+    "ghcr.io/devcontainers/features/copilot-cli:1": {},
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "configureZshAsDefaultShell": true
+    },
+    "ghcr.io/devcontainers-extra/features/ripgrep:1": {}
+  }
+}

--- a/packages/core/templates/devcontainer.json.node.hbs
+++ b/packages/core/templates/devcontainer.json.node.hbs
@@ -1,0 +1,55 @@
+{
+  "containerEnv": {
+    "GH_TOKEN": "${localEnv:DDEV_AGENTS_GH_TOKEN}",
+    "WQS_MCP_API_KEY": "${localEnv:WQS_MCP_API_KEY}"
+  },
+  "remoteEnv": {
+    "GH_TOKEN": "${localEnv:DDEV_AGENTS_GH_TOKEN}",
+    "WQS_MCP_API_KEY": "${localEnv:WQS_MCP_API_KEY}",
+    "SSH_AUTH_SOCK": ""
+  },
+  "name": "Agents: {{projectName}}",
+  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "{{nodeVersion}}"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "installDirectlyFromGitHubRelease": true
+    },
+    "ghcr.io/devcontainers/features/copilot-cli:1": {},
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "configureZshAsDefaultShell": true
+    },
+    "ghcr.io/devcontainers-extra/features/ripgrep:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "github.copilot",
+        "github.copilot-chat",
+        "davidanson.vscode-markdownlint",
+        "ms-azuretools.vscode-docker",
+        "redhat.vscode-yaml"
+      ],
+      "settings": {
+        "git.enabled": true,
+        "workbench.activityBar.visible": true,
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "github.copilot.enable": {
+          "*": true
+        },
+        "editor.formatOnSave": true,
+        "chat.mcp.gallery.enabled": true,
+        "chat.mcp.gallery.serviceUrl": "https://mcp.wdr.io"
+      }
+    }
+  },
+  "mounts": [
+    "source=${localWorkspaceFolder}/.devcontainer/copilot-managed-config.json,target=/home/vscode/.copilot-managed-config.json,type=bind,readonly"
+  ],
+  "postAttachCommand": "echo '✅ Secure Agents Environment Active'",
+  "remoteUser": "vscode"
+}

--- a/packages/core/templates/devcontainer.json.php.hbs
+++ b/packages/core/templates/devcontainer.json.php.hbs
@@ -1,0 +1,70 @@
+{
+  "containerEnv": {
+    "GH_TOKEN": "${localEnv:DDEV_AGENTS_GH_TOKEN}",
+    "WQS_MCP_API_KEY": "${localEnv:WQS_MCP_API_KEY}"
+  },
+  "remoteEnv": {
+    "GH_TOKEN": "${localEnv:DDEV_AGENTS_GH_TOKEN}",
+    "WQS_MCP_API_KEY": "${localEnv:WQS_MCP_API_KEY}",
+    "SSH_AUTH_SOCK": ""
+  },
+  "name": "Agents: __PROJECT_NAME__",
+  "dockerComposeFile": [
+    "../.ddev/.ddev-docker-compose-full.yaml"
+  ],
+  "service": "agents",
+  "workspaceFolder": "/workspace",
+  "shutdownAction": "none",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "__NODE_VERSION__"
+    },
+    "ghcr.io/shyim/devcontainers-features/php:latest": {
+      "version": "__PHP_VERSION__",
+      "installComposer": true
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "installDirectlyFromGitHubRelease": true
+    },
+    "ghcr.io/devcontainers/features/copilot-cli:1": {},
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "configureZshAsDefaultShell": true
+    },
+    "ghcr.io/devcontainers-extra/features/ripgrep:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "github.copilot",
+        "github.copilot-chat",
+        "davidanson.vscode-markdownlint",
+        "ms-azuretools.vscode-docker",
+        "redhat.vscode-yaml"
+      ],
+      "settings": {
+        "git.enabled": true,
+        "workbench.activityBar.visible": true,
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "github.copilot.enable": {
+          "*": true
+        },
+        "editor.formatOnSave": true,
+        "chat.mcp.gallery.enabled": true,
+        "chat.mcp.gallery.serviceUrl": "https://mcp.wdr.io"
+      }
+    },
+    "jetbrains": {
+      "backend": "PhpStorm",
+      "plugins": [
+        "org.jetbrains.plugins.github",
+        "org.intellij.plugins.markdown",
+        "Docker",
+        "com.github.copilot"
+      ]
+    }
+  },
+  "postAttachCommand": "echo '✅ Secure Agents Environment Active'",
+  "remoteUser": "vscode"
+}

--- a/packages/core/templates/mcp-config.json.hbs
+++ b/packages/core/templates/mcp-config.json.hbs
@@ -1,0 +1,31 @@
+{
+  "mcpServers": {
+    "wdrmcp": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@wunderio/wdrmcp@{{wdrmcpVersion}}",
+        "--tools-config",
+        "{{toolsConfigPath}}"
+      ],
+      "env": {
+        "DDEV_PROJECT": "{{projectName}}"
+      },
+      "tools": ["*"]
+    },
+    "wunder-quality-system": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "supergateway@{{supergatewayVersion}}",
+        "--streamableHttp",
+        "https://quality.wunder.io/mcp",
+        "--oauth2Bearer",
+        "{{wqsApiKey}}"
+      ],
+      "tools": ["*"]
+    }
+  }
+}

--- a/packages/core/templates/mcp-config.json.hbs
+++ b/packages/core/templates/mcp-config.json.hbs
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@wunderio/wdrmcp@{{wdrmcpVersion}}",
+        "@wunderio/wdrmcp",
         "--tools-config",
         "{{toolsConfigPath}}"
       ],
@@ -19,7 +19,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "supergateway@{{supergatewayVersion}}",
+        "supergateway",
         "--streamableHttp",
         "https://quality.wunder.io/mcp",
         "--oauth2Bearer",

--- a/packages/core/templates/vscode-mcp.json.hbs
+++ b/packages/core/templates/vscode-mcp.json.hbs
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@wunderio/wdrmcp@{{wdrmcpVersion}}",
+        "@wunderio/wdrmcp",
         "--tools-config",
         "{{toolsConfigPath}}"
       ],
@@ -17,7 +17,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "supergateway@{{supergatewayVersion}}",
+        "supergateway",
         "--streamableHttp",
         "https://quality.wunder.io/mcp",
         "--oauth2Bearer",

--- a/packages/core/templates/vscode-mcp.json.hbs
+++ b/packages/core/templates/vscode-mcp.json.hbs
@@ -1,0 +1,31 @@
+{
+  "servers": {
+    "wdrmcp": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@wunderio/wdrmcp@{{wdrmcpVersion}}",
+        "--tools-config",
+        "{{toolsConfigPath}}"
+      ],
+      "gallery": "https://mcp.wdr.io",
+      "version": "{{wdrmcpVersion}}"
+    },
+    "wunder-quality-system": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "supergateway@{{supergatewayVersion}}",
+        "--streamableHttp",
+        "https://quality.wunder.io/mcp",
+        "--oauth2Bearer",
+        "{{wqsApiKey}}"
+      ],
+      "gallery": "https://mcp.wdr.io",
+      "version": "1.0.0"
+    }
+  },
+  "inputs": []
+}

--- a/packages/npm-cli/.agents/tools-config/README.md
+++ b/packages/npm-cli/.agents/tools-config/README.md
@@ -1,0 +1,9 @@
+# Node Agents MCP Tool Configs
+
+These YAML files define the tools exposed by the wdrmcp server for node/npm
+projects.
+
+- `node-tools.yml` — npm/yarn/pnpm install, CI, run scripts, npx, and logs.
+
+All tools execute locally inside the agents container at `/workspace` (there is
+no separate DDEV web container for this flavour).

--- a/packages/npm-cli/.agents/tools-config/node-tools.yml
+++ b/packages/npm-cli/.agents/tools-config/node-tools.yml
@@ -1,0 +1,185 @@
+# Node/npm project tools (local execution, no DDEV web container)
+#
+# These tools run inside the agents container at /workspace.
+# Package manager is auto-detected from lockfile unless explicitly specified.
+
+tools:
+  - name: node_install
+    enabled: true
+    description: |
+      Install dependencies for the node project.
+
+      Auto-detects package manager from lockfile (pnpm-lock.yaml → yarn.lock → npm)
+      unless package_manager is explicitly set.
+    type: command
+    command_template: 'PM={package_manager}; if [ "$PM" = "auto" ]; then if [ -f /workspace/pnpm-lock.yaml ]; then PM=pnpm; elif [ -f /workspace/yarn.lock ]; then PM=yarn; else PM=npm; fi; fi; cd /workspace && $PM install {args}'
+    working_dir: "/workspace"
+    default_args:
+      package_manager: "auto"
+      args: []
+    input_schema:
+      type: object
+      properties:
+        package_manager:
+          type: string
+          enum: ["auto", "npm", "yarn", "pnpm"]
+          default: "auto"
+          description: Package manager to use.
+        args:
+          type: array
+          items:
+            type: string
+          description: Extra arguments passed to the install command.
+
+  - name: node_ci
+    enabled: true
+    description: |
+      Install dependencies using the lockfile (npm ci / yarn install --frozen-lockfile / pnpm install --frozen-lockfile).
+
+      Auto-detects package manager from lockfile unless explicitly specified.
+    type: command
+    command_template: 'PM={package_manager}; if [ "$PM" = "auto" ]; then if [ -f /workspace/pnpm-lock.yaml ]; then PM=pnpm; elif [ -f /workspace/yarn.lock ]; then PM=yarn; else PM=npm; fi; fi; cd /workspace && if [ "$PM" = "npm" ]; then npm ci {args}; elif [ "$PM" = "yarn" ]; then yarn install --frozen-lockfile {args}; else pnpm install --frozen-lockfile {args}; fi'
+    working_dir: "/workspace"
+    default_args:
+      package_manager: "auto"
+      args: []
+    input_schema:
+      type: object
+      properties:
+        package_manager:
+          type: string
+          enum: ["auto", "npm", "yarn", "pnpm"]
+          default: "auto"
+          description: Package manager to use.
+        args:
+          type: array
+          items:
+            type: string
+          description: Extra arguments passed to the install command.
+
+  - name: node_run
+    enabled: true
+    description: |
+      Run an npm script by name.
+
+      Auto-detects package manager from lockfile unless explicitly specified.
+    type: command
+    command_template: 'PM={package_manager}; if [ "$PM" = "auto" ]; then if [ -f /workspace/pnpm-lock.yaml ]; then PM=pnpm; elif [ -f /workspace/yarn.lock ]; then PM=yarn; else PM=npm; fi; fi; cd /workspace && $PM run {script} -- {args}'
+    working_dir: "/workspace"
+    default_args:
+      package_manager: "auto"
+      args: []
+    input_schema:
+      type: object
+      properties:
+        package_manager:
+          type: string
+          enum: ["auto", "npm", "yarn", "pnpm"]
+          default: "auto"
+          description: Package manager to use.
+        script:
+          type: string
+          description: Name of the npm script to run.
+        args:
+          type: array
+          items:
+            type: string
+          description: Extra arguments passed after the script name.
+      required:
+        - script
+
+  - name: node_run_build
+    enabled: true
+    description: |
+      Build the project (runs the "build" script).
+    type: command
+    command_template: 'PM={package_manager}; if [ "$PM" = "auto" ]; then if [ -f /workspace/pnpm-lock.yaml ]; then PM=pnpm; elif [ -f /workspace/yarn.lock ]; then PM=yarn; else PM=npm; fi; fi; cd /workspace && $PM run build'
+    working_dir: "/workspace"
+    default_args:
+      package_manager: "auto"
+    input_schema:
+      type: object
+      properties:
+        package_manager:
+          type: string
+          enum: ["auto", "npm", "yarn", "pnpm"]
+          default: "auto"
+          description: Package manager to use.
+
+  - name: node_run_test
+    enabled: true
+    description: |
+      Run the test suite (runs the "test" script).
+
+      Non-zero exit codes are reported as test failures rather than command errors.
+    type: check
+    command_template: 'PM={package_manager}; if [ "$PM" = "auto" ]; then if [ -f /workspace/pnpm-lock.yaml ]; then PM=pnpm; elif [ -f /workspace/yarn.lock ]; then PM=yarn; else PM=npm; fi; fi; cd /workspace && $PM run test'
+    working_dir: "/workspace"
+    success_exit_codes: [1, 2]
+    default_args:
+      package_manager: "auto"
+    input_schema:
+      type: object
+      properties:
+        package_manager:
+          type: string
+          enum: ["auto", "npm", "yarn", "pnpm"]
+          default: "auto"
+          description: Package manager to use.
+
+  - name: node_run_lint
+    enabled: true
+    description: |
+      Run the linter (runs the "lint" script).
+
+      Non-zero exit codes are reported as lint failures rather than command errors.
+    type: check
+    command_template: 'PM={package_manager}; if [ "$PM" = "auto" ]; then if [ -f /workspace/pnpm-lock.yaml ]; then PM=pnpm; elif [ -f /workspace/yarn.lock ]; then PM=yarn; else PM=npm; fi; fi; cd /workspace && $PM run lint'
+    working_dir: "/workspace"
+    success_exit_codes: [1, 2]
+    default_args:
+      package_manager: "auto"
+    input_schema:
+      type: object
+      properties:
+        package_manager:
+          type: string
+          enum: ["auto", "npm", "yarn", "pnpm"]
+          default: "auto"
+          description: Package manager to use.
+
+  - name: npx
+    enabled: true
+    description: |
+      Run npx inside the agents container.
+    type: command
+    command_template: "cd /workspace && npx {args}"
+    working_dir: "/workspace"
+    default_args:
+      args: []
+    input_schema:
+      type: object
+      properties:
+        args:
+          type: array
+          items:
+            type: string
+          description: Arguments passed to npx.
+
+  - name: node_logs
+    enabled: true
+    description: |
+      Read recent application logs if available.
+
+      Falls back to stdout if no dedicated log file exists.
+    type: command
+    command_template: 'cd /workspace && (ls logs/*.log 2>/dev/null && tail -n {lines} logs/*.log) || echo "No logs/ directory found; app logs typically go to stdout/stderr in node projects."'
+    working_dir: "/workspace"
+    default_args:
+      lines: "100"
+    input_schema:
+      type: object
+      properties:
+        lines:
+          type: integer
+          description: Number of log lines to return (default 100, max 1000)

--- a/packages/npm-cli/.devcontainer/README.md
+++ b/packages/npm-cli/.devcontainer/README.md
@@ -1,0 +1,5 @@
+# Dev Container configuration
+
+`agents set-up` generates `devcontainer.json` in this directory from the shared
+core templates. This directory also receives a read-only copy of
+`copilot-managed-config.json` so it can be bind-mounted into the container.

--- a/packages/npm-cli/README.md
+++ b/packages/npm-cli/README.md
@@ -1,0 +1,154 @@
+# @wunderio/node-agents
+
+Isolated AI agent environment for node/npm projects. No DDEV required.
+
+## What it is
+
+`@wunderio/node-agents` brings the same secure, containerised agentic workflow
+that Wunder.io uses for PHP/Drupal projects to node/npm projects:
+
+- Isolated devcontainer with GitHub Copilot CLI
+- Pre-configured MCP tools for npm/yarn/pnpm (install, ci, run, build, test, lint, npx)
+- Wunder Quality System MCP integration
+- Read-only managed security config (`copilot-managed-config.json`)
+- `cap_drop: ALL` + `no-new-privileges` hardening
+- `GH_TOKEN` / `WQS_MCP_API_KEY` injected via devcontainer `remoteEnv`
+
+## When to use this vs. the DDEV add-on
+
+Use `@wunderio/node-agents` when your project is **not** a PHP/Drupal project
+and does **not** use DDEV. If you already use DDEV, use the
+`wunderio/ddev-agents` add-on instead.
+
+## Prerequisites
+
+- Node.js 20+ and npm on the host
+- Docker (or Docker-compatible runtime) on the host
+
+## Installation
+
+```bash
+npm install --save-dev @wunderio/node-agents
+```
+
+Recommended `package.json` scripts:
+
+```json
+{
+  "scripts": {
+    "agents:build": "agents build",
+    "agents:setup": "agents set-up",
+    "copilot": "agents copilot"
+  }
+}
+```
+
+## Authentication
+
+### GitHub token
+
+Create a GitHub Personal Access Token with **Copilot Requests: Read-only**
+permission, then export it on your host:
+
+```bash
+export DDEV_AGENTS_GH_TOKEN=your_token_here
+```
+
+The token is passed into the container via `remoteEnv` and is never written to
+the image or container filesystem.
+
+### WQS API key (optional)
+
+Export the Wunder Quality System MCP API key on your host:
+
+```bash
+export WQS_MCP_API_KEY=your_key_here
+```
+
+## Commands
+
+All commands run inside the isolated agents container.
+
+### `agents build`
+
+Build the devcontainer image. Node.js version is auto-detected from `.nvmrc`
+or `package.json` `engines.node`, with an optional override:
+
+```bash
+agents build
+agents build --node-version 20
+```
+
+### `agents set-up`
+
+Build (if needed), start the container, generate MCP configs, and symlink
+`~/.copilot` to `/workspace/.copilot` for persistence.
+
+```bash
+agents set-up
+```
+
+### `agents copilot [args]`
+
+Run GitHub Copilot CLI.
+
+```bash
+agents copilot
+agents copilot -p "explain this code"
+agents copilot --version
+```
+
+### `agents start` / `agents stop`
+
+Start or stop the agents container.
+
+### `agents npm [args]` / `agents npx [args]`
+
+Passthrough to npm/npx inside the container.
+
+```bash
+agents npm install
+agents npm run build
+agents npx eslint .
+```
+
+### `agents exec <command> [args...]`
+
+Run an arbitrary command inside the container.
+
+```bash
+agents exec -- node -v
+agents exec -- git status
+```
+
+## MCP tools
+
+After `agents set-up`, the wdrmcp server exposes node/npm tools defined in
+`.agents/tools-config/node-tools.yml`:
+
+- `node_install` / `node_ci` — dependency install
+- `node_run` / `node_run_build` / `node_run_test` / `node_run_lint`
+- `npx`
+- `node_logs`
+
+The package manager is auto-detected from the lockfile (`pnpm-lock.yaml`,
+`yarn.lock`, `package-lock.json`) unless explicitly overridden.
+
+## Security
+
+- Token-based auth via host environment variables
+- Managed config mounted read-only at `/home/vscode/.copilot-managed-config.json`
+- Container runs with `cap_drop: ALL` and `no-new-privileges:true`
+- `SSH_AUTH_SOCK` is cleared in `remoteEnv`
+- No secrets stored in the image or container filesystem
+
+## Troubleshooting
+
+**Container fails to start:** ensure Docker is running and the devcontainer CLI
+can reach it. The first run may take several minutes to build the image.
+
+**Copilot authentication fails:** verify `DDEV_AGENTS_GH_TOKEN` is exported in
+the shell where you run `agents`.
+
+**MCP tools not visible:** restart the wdrmcp server from VS Code or reload the
+window.

--- a/packages/npm-cli/bin/agents
+++ b/packages/npm-cli/bin/agents
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { main } from '../src/cli.js';
+
+main(process.argv.slice(2)).catch((err) => {
+  console.error(err?.message ?? err);
+  process.exit(err?.exitCode ?? 1);
+});

--- a/packages/npm-cli/package.json
+++ b/packages/npm-cli/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@wunderio/node-agents",
+  "version": "1.0.0",
+  "description": "Isolated AI agent environment for node/npm projects (no DDEV required).",
+  "bin": {
+    "agents": "./bin/agents"
+  },
+  "type": "module",
+  "files": [
+    "bin/",
+    "src/",
+    ".agents/",
+    ".devcontainer/"
+  ],
+  "scripts": {
+    "build": "echo 'No build step required'",
+    "test": "node --test src/**/*.test.js",
+    "lint": "echo 'No linter configured'"
+  },
+  "dependencies": {
+    "@wunderio/agents-core": "^1.0.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/npm-cli/src/cli.js
+++ b/packages/npm-cli/src/cli.js
@@ -1,0 +1,59 @@
+import { resolveProjectRoot } from './lib/config.js';
+import { build } from './commands/build.js';
+import { setUp } from './commands/set-up.js';
+import { copilot } from './commands/copilot.js';
+import { start } from './commands/start.js';
+import { stop } from './commands/stop.js';
+import { npm } from './commands/npm.js';
+import { npx } from './commands/npx.js';
+import { exec } from './commands/exec.js';
+
+const COMMANDS = {
+  build,
+  'set-up': setUp,
+  setup: setUp,
+  copilot,
+  start,
+  stop,
+  npm,
+  npx,
+  exec,
+};
+
+function printUsage() {
+  console.log(`Usage: agents <command> [options]
+
+Commands:
+  build              Build the agents devcontainer image
+  set-up             Start the container and apply devcontainer metadata
+  copilot [args]     Run GitHub Copilot CLI inside the container
+  start              Start the agents container
+  stop               Stop the agents container
+  npm [args]         Run npm inside the container
+  npx [args]         Run npx inside the container
+  exec [args]        Run an arbitrary command inside the container
+
+Environment variables:
+  DDEV_AGENTS_GH_TOKEN   GitHub token for Copilot CLI auth
+  WQS_MCP_API_KEY        Wunder Quality System MCP API key (optional)
+`);
+}
+
+export async function main(args) {
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    printUsage();
+    return 0;
+  }
+
+  const [commandName, ...commandArgs] = args;
+  const command = COMMANDS[commandName];
+
+  if (!command) {
+    console.error(`Unknown command: ${commandName}`);
+    printUsage();
+    return 1;
+  }
+
+  const projectRoot = resolveProjectRoot();
+  return command({ projectRoot, args: commandArgs });
+}

--- a/packages/npm-cli/src/commands/build.js
+++ b/packages/npm-cli/src/commands/build.js
@@ -1,0 +1,37 @@
+import { writeDevcontainerConfig, execDevcontainer, resolveNodeVersion } from '../lib/container.js';
+import { getProjectName } from '../lib/config.js';
+
+export async function build({ projectRoot, args = [] }) {
+  const explicitNodeVersion = parseExplicitArg(args, '--node-version');
+  const projectName = getProjectName(projectRoot);
+  const nodeVersion = resolveNodeVersion({ projectRoot, explicitVersion: explicitNodeVersion });
+
+  console.log(`🔍 Project: ${projectName}`);
+  console.log(`📍 Node.js version: ${nodeVersion}`);
+
+  const configPath = writeDevcontainerConfig({ projectRoot, projectName, nodeVersion });
+  console.log(`📝 Wrote ${configPath}`);
+
+  console.log('🔨 Building agents devcontainer image...');
+  const exitCode = await execDevcontainer([
+    'build',
+    '--workspace-folder', projectRoot,
+    '--config', configPath,
+    '--image-name', `${projectName}-agents:latest`
+  ]);
+
+  if (exitCode !== 0) {
+    throw new Error(`Devcontainer build failed with exit code ${exitCode}`);
+  }
+
+  console.log(`✅ Image built: ${projectName}-agents:latest`);
+  return 0;
+}
+
+function parseExplicitArg(args, flag) {
+  const idx = args.indexOf(flag);
+  if (idx !== -1 && args[idx + 1]) {
+    return args[idx + 1];
+  }
+  return null;
+}

--- a/packages/npm-cli/src/commands/copilot.js
+++ b/packages/npm-cli/src/commands/copilot.js
@@ -1,0 +1,5 @@
+import { invokeCopilot } from '@wunderio/agents-core';
+
+export async function copilot({ projectRoot, args = [] }) {
+  return invokeCopilot({ workspaceFolder: projectRoot, args });
+}

--- a/packages/npm-cli/src/commands/exec.js
+++ b/packages/npm-cli/src/commands/exec.js
@@ -1,0 +1,15 @@
+import { execDevcontainer } from '../lib/container.js';
+
+export async function exec({ projectRoot, args = [] }) {
+  if (args.length === 0) {
+    console.error('Usage: agents exec <command> [args...]');
+    return 1;
+  }
+
+  const exitCode = await execDevcontainer([
+    'exec',
+    '--workspace-folder', projectRoot,
+    ...args
+  ]);
+  return exitCode;
+}

--- a/packages/npm-cli/src/commands/npm.js
+++ b/packages/npm-cli/src/commands/npm.js
@@ -1,0 +1,11 @@
+import { execDevcontainer } from '../lib/container.js';
+
+export async function npm({ projectRoot, args = [] }) {
+  const exitCode = await execDevcontainer([
+    'exec',
+    '--workspace-folder', projectRoot,
+    'npm',
+    ...args
+  ]);
+  return exitCode;
+}

--- a/packages/npm-cli/src/commands/npx.js
+++ b/packages/npm-cli/src/commands/npx.js
@@ -1,0 +1,11 @@
+import { execDevcontainer } from '../lib/container.js';
+
+export async function npx({ projectRoot, args = [] }) {
+  const exitCode = await execDevcontainer([
+    'exec',
+    '--workspace-folder', projectRoot,
+    'npx',
+    ...args
+  ]);
+  return exitCode;
+}

--- a/packages/npm-cli/src/commands/set-up.js
+++ b/packages/npm-cli/src/commands/set-up.js
@@ -1,0 +1,166 @@
+import { writeDevcontainerConfig, execDevcontainer, resolveNodeVersion } from '../lib/container.js';
+import { getProjectName, getToolsConfigPath } from '../lib/config.js';
+import { getPackageVersions, generateCliMcpConfig, generateVscodeMcpConfig } from '../lib/mcp.js';
+import { resolve } from 'node:path';
+import {
+  existsSync,
+  mkdirSync,
+  copyFileSync,
+  cpSync,
+  writeFileSync,
+  readFileSync,
+  appendFileSync
+} from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const packageRoot = resolve(__dirname, '../..');
+
+export async function setUp({ projectRoot, args = [] }) {
+  const explicitNodeVersion = parseExplicitArg(args, '--node-version');
+  const projectName = getProjectName(projectRoot);
+  const nodeVersion = resolveNodeVersion({ projectRoot, explicitVersion: explicitNodeVersion });
+
+  console.log(`🔍 Project: ${projectName}`);
+  console.log(`📍 Node.js version: ${nodeVersion}`);
+
+  // Write devcontainer.json
+  const configPath = writeDevcontainerConfig({ projectRoot, projectName, nodeVersion });
+  console.log(`📝 Wrote ${configPath}`);
+
+  // Copy managed config into project so devcontainer can bind-mount it
+  const managedConfigSource = resolveCoreTemplatePath('copilot-managed-config.json');
+  const managedConfigDest = resolve(projectRoot, '.devcontainer', 'copilot-managed-config.json');
+  copyFileSync(managedConfigSource, managedConfigDest);
+  console.log(`📝 Copied managed config to ${managedConfigDest}`);
+
+  // Copy node tool configs into project
+  const toolsConfigDest = getToolsConfigPath(projectRoot);
+  if (!existsSync(toolsConfigDest)) {
+    const toolsConfigSource = resolve(packageRoot, '.agents', 'tools-config');
+    mkdirSync(toolsConfigDest, { recursive: true });
+    cpSync(toolsConfigSource, toolsConfigDest, { recursive: true });
+    console.log(`📝 Copied default tool configs to ${toolsConfigDest}`);
+  } else {
+    console.log(`ℹ️  Tool configs already exist at ${toolsConfigDest}`);
+  }
+
+  // Ensure .copilot persistence directory exists on host
+  const copilotDir = resolve(projectRoot, '.copilot');
+  mkdirSync(copilotDir, { recursive: true });
+  ensureGitignored(projectRoot, '.copilot');
+
+  // Bring up the devcontainer
+  console.log('🚀 Starting agents devcontainer...');
+  const upCode = await execDevcontainer([
+    'up',
+    '--workspace-folder', projectRoot
+  ]);
+  if (upCode !== 0) {
+    throw new Error(`devcontainer up failed with exit code ${upCode}`);
+  }
+
+  // Generate MCP configs
+  const { wdrmcpVersion, supergatewayVersion } = await getPackageVersions();
+  const toolsConfigPath = '/workspace/.agents/tools-config';
+
+  const cliMcpConfig = generateCliMcpConfig({
+    projectName,
+    toolsConfigPath,
+    wdrmcpVersion,
+    supergatewayVersion
+  });
+
+  const vscodeMcpConfig = generateVscodeMcpConfig({
+    projectName,
+    toolsConfigPath,
+    wdrmcpVersion,
+    supergatewayVersion
+  });
+
+  // Write CLI MCP config inside container
+  await execInContainer(projectRoot, [
+    'bash', '-c',
+    `mkdir -p ~/.copilot && cat > ~/.copilot/mcp-config.json`,
+  ], { input: cliMcpConfig });
+  console.log('✅ Wrote Copilot CLI MCP config');
+
+  // Symlink ~/.copilot to /workspace/.copilot
+  await execInContainer(projectRoot, [
+    'bash', '-c',
+    `
+      if [ -e ~/.copilot ] && [ ! -L ~/.copilot ]; then
+        cp -rT ~/.copilot /workspace/.copilot 2>/dev/null && rm -rf ~/.copilot || {
+          echo "⚠️ Could not migrate ~/.copilot" >&2;
+          exit 1;
+        }
+      fi
+      ln -sfn /workspace/.copilot ~/.copilot
+    `
+  ]);
+  console.log('✅ Symlinked ~/.copilot to /workspace/.copilot');
+
+  // Write VS Code User mcp.json inside container
+  await execInContainer(projectRoot, [
+    'bash', '-c',
+    `mkdir -p ~/.vscode-server/data/User && cat > ~/.vscode-server/data/User/mcp.json`
+  ], { input: vscodeMcpConfig });
+  console.log('✅ Wrote VS Code MCP config');
+
+  console.log('');
+  console.log('✅ Setup complete. Run `agents copilot` or attach VS Code to the devcontainer.');
+  return 0;
+}
+
+function parseExplicitArg(args, flag) {
+  const idx = args.indexOf(flag);
+  if (idx !== -1 && args[idx + 1]) {
+    return args[idx + 1];
+  }
+  return null;
+}
+
+function resolveCoreTemplatePath(name) {
+  return fileURLToPath(import.meta.resolve(`@wunderio/agents-core/templates/${name}`));
+}
+
+function ensureGitignored(projectRoot, entry) {
+  const gitignorePath = resolve(projectRoot, '.gitignore');
+  const line = entry.startsWith('.') ? entry : `.${entry}`;
+  if (existsSync(gitignorePath)) {
+    const contents = readFileSync(gitignorePath, 'utf8');
+    if (!contents.split('\n').includes(line)) {
+      appendFileSync(gitignorePath, `\n${line}\n`);
+      console.log(`✅ Added ${line} to .gitignore`);
+    }
+  } else {
+    writeFileSync(gitignorePath, `${line}\n`);
+    console.log(`✅ Created .gitignore with ${line}`);
+  }
+}
+
+async function execInContainer(projectRoot, command, { input } = {}) {
+  const { spawn } = await import('node:child_process');
+  const args = ['exec', '--workspace-folder', projectRoot, ...command];
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('devcontainer', args, {
+      stdio: ['pipe', 'inherit', 'inherit']
+    });
+
+    if (input) {
+      child.stdin.write(input);
+      child.stdin.end();
+    }
+
+    child.on('close', (code) => {
+      if (code === 0 || code === null) {
+        resolve(code ?? 0);
+      } else {
+        reject(new Error(`Container command failed with exit code ${code}`));
+      }
+    });
+
+    child.on('error', reject);
+  });
+}

--- a/packages/npm-cli/src/commands/set-up.js
+++ b/packages/npm-cli/src/commands/set-up.js
@@ -1,4 +1,4 @@
-import { writeDevcontainerConfig, execDevcontainer, resolveNodeVersion } from '../lib/container.js';
+import { writeDevcontainerConfig, devcontainerUp, resolveNodeVersion } from '../lib/container.js';
 import { getProjectName, getToolsConfigPath } from '../lib/config.js';
 import { getPackageVersions, generateCliMcpConfig, generateVscodeMcpConfig } from '../lib/mcp.js';
 import { resolve } from 'node:path';
@@ -52,17 +52,19 @@ export async function setUp({ projectRoot, args = [] }) {
 
   // Bring up the devcontainer
   console.log('🚀 Starting agents devcontainer...');
-  const upCode = await execDevcontainer([
-    'up',
-    '--workspace-folder', projectRoot
-  ]);
+  const { code: upCode, remoteWorkspaceFolder } = await devcontainerUp(projectRoot);
   if (upCode !== 0) {
     throw new Error(`devcontainer up failed with exit code ${upCode}`);
   }
+  // The devcontainer CLI chooses the container-side workspace folder (typically
+  // /workspaces/<project>, NOT /workspace). Everything we write inside the
+  // container must be anchored to this path, not a hardcoded one.
+  const workspaceFolder = remoteWorkspaceFolder || '/workspace';
+  const copilotDataDir = `${workspaceFolder}/.copilot`;
 
   // Generate MCP configs
   const { wdrmcpVersion, supergatewayVersion } = await getPackageVersions();
-  const toolsConfigPath = '/workspace/.agents/tools-config';
+  const toolsConfigPath = `${workspaceFolder}/.agents/tools-config`;
 
   const cliMcpConfig = generateCliMcpConfig({
     projectName,
@@ -78,27 +80,37 @@ export async function setUp({ projectRoot, args = [] }) {
     supergatewayVersion
   });
 
-  // Write CLI MCP config inside container
+  // Persist Copilot session data by symlinking ~/.copilot to the
+  // ${copilotDataDir} bind-mount (survives restarts). Do this BEFORE writing
+  // any config so the MCP config lands in the persisted location. Any
+  // pre-existing real ~/.copilot is migrated best-effort — a migration problem
+  // must never abort setup, otherwise the symlink and configs below never get
+  // written and Copilot ends up without working MCP settings.
+  await execInContainer(projectRoot, [
+    'bash', '-c',
+    `
+      mkdir -p ${copilotDataDir}
+      if [ -e ~/.copilot ] && [ ! -L ~/.copilot ]; then
+        if cp -rn ~/.copilot/. ${copilotDataDir}/ 2>/tmp/copilot-migrate.err; then
+          rm -rf ~/.copilot
+        else
+          echo "⚠️ Could not fully migrate existing ~/.copilot to ${copilotDataDir}:" >&2
+          sed 's/^/   /' /tmp/copilot-migrate.err >&2
+          echo "   Continuing anyway; new session data will be stored in ${copilotDataDir}." >&2
+          rm -rf ~/.copilot
+        fi
+      fi
+      ln -sfn ${copilotDataDir} ~/.copilot
+    `
+  ]);
+  console.log(`✅ Symlinked ~/.copilot to ${copilotDataDir}`);
+
+  // Write CLI MCP config (through the symlink, into ${copilotDataDir})
   await execInContainer(projectRoot, [
     'bash', '-c',
     `mkdir -p ~/.copilot && cat > ~/.copilot/mcp-config.json`,
   ], { input: cliMcpConfig });
   console.log('✅ Wrote Copilot CLI MCP config');
-
-  // Symlink ~/.copilot to /workspace/.copilot
-  await execInContainer(projectRoot, [
-    'bash', '-c',
-    `
-      if [ -e ~/.copilot ] && [ ! -L ~/.copilot ]; then
-        cp -rT ~/.copilot /workspace/.copilot 2>/dev/null && rm -rf ~/.copilot || {
-          echo "⚠️ Could not migrate ~/.copilot" >&2;
-          exit 1;
-        }
-      fi
-      ln -sfn /workspace/.copilot ~/.copilot
-    `
-  ]);
-  console.log('✅ Symlinked ~/.copilot to /workspace/.copilot');
 
   // Write VS Code User mcp.json inside container
   await execInContainer(projectRoot, [

--- a/packages/npm-cli/src/commands/start.js
+++ b/packages/npm-cli/src/commands/start.js
@@ -1,0 +1,19 @@
+import { execDevcontainer } from '../lib/container.js';
+import { getProjectName } from '../lib/config.js';
+
+export async function start({ projectRoot, args = [] }) {
+  const projectName = getProjectName(projectRoot);
+  console.log(`🚀 Starting agents container for ${projectName}...`);
+
+  const exitCode = await execDevcontainer([
+    'up',
+    '--workspace-folder', projectRoot
+  ]);
+
+  if (exitCode !== 0) {
+    throw new Error(`Failed to start container (exit ${exitCode})`);
+  }
+
+  console.log('✅ Agents container started.');
+  return 0;
+}

--- a/packages/npm-cli/src/commands/stop.js
+++ b/packages/npm-cli/src/commands/stop.js
@@ -1,7 +1,6 @@
-import { execDevcontainer } from '../lib/container.js';
-import { getProjectName } from '../lib/config.js';
+import { getProjectName, getContainerName } from '../lib/config.js';
 
-export async function stop({ projectRoot, args = [] }) {
+export async function stop({ projectRoot, args: _args = [] }) {
   const projectName = getProjectName(projectRoot);
   console.log(`🛑 Stopping agents container for ${projectName}...`);
 
@@ -10,8 +9,7 @@ export async function stop({ projectRoot, args = [] }) {
   // label. The container created by `devcontainer up` is labelled with the
   // devcontainer config path, so we stop the container named after the project.
   const { spawn } = await import('node:child_process');
-  const containerName = `${projectName}-agents`;
-
+  const containerName = getContainerName(projectName);
   return new Promise((resolve, reject) => {
     const child = spawn('docker', ['stop', containerName], { stdio: 'inherit' });
     child.on('close', (code) => {

--- a/packages/npm-cli/src/commands/stop.js
+++ b/packages/npm-cli/src/commands/stop.js
@@ -1,0 +1,29 @@
+import { execDevcontainer } from '../lib/container.js';
+import { getProjectName } from '../lib/config.js';
+
+export async function stop({ projectRoot, args = [] }) {
+  const projectName = getProjectName(projectRoot);
+  console.log(`🛑 Stopping agents container for ${projectName}...`);
+
+  // devcontainer CLI does not have a direct "down" command for an existing
+  // running container in all versions; fall back to docker stop by container
+  // label. The container created by `devcontainer up` is labelled with the
+  // devcontainer config path, so we stop the container named after the project.
+  const { spawn } = await import('node:child_process');
+  const containerName = `${projectName}-agents`;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('docker', ['stop', containerName], { stdio: 'inherit' });
+    child.on('close', (code) => {
+      if (code === 0 || code === null) {
+        console.log('✅ Agents container stopped.');
+        resolve(0);
+      } else {
+        // If the container does not exist, treat as already stopped.
+        console.log('ℹ️  Container already stopped or not found.');
+        resolve(0);
+      }
+    });
+    child.on('error', reject);
+  });
+}

--- a/packages/npm-cli/src/lib/config.js
+++ b/packages/npm-cli/src/lib/config.js
@@ -9,19 +9,29 @@ export function resolveProjectRoot() {
   return cwd();
 }
 
+import { createHash } from 'node:crypto';
+
 export function getProjectName(projectRoot) {
   const packageJsonPath = resolve(projectRoot, 'package.json');
   if (existsSync(packageJsonPath)) {
     try {
       const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
       if (pkg.name) {
-        return String(pkg.name).replace(/^@[^/]+\//, '').replace(/[^a-zA-Z0-9_-]/g, '-');
+        const name = String(pkg.name)
+          .replace(/^@[^/]+\//, '')
+          .replace(/[^a-zA-Z0-9_-]/g, '-');
+        const suffix = createHash('sha256')
+          .update(resolve(projectRoot))
+          .digest('hex')
+          .slice(0, 8);
+        return `${name}-${suffix}`;
       }
     } catch {
       // fall through
     }
   }
   return 'node-agents';
+}
 }
 
 export function getDevcontainerConfigPath(projectRoot) {

--- a/packages/npm-cli/src/lib/config.js
+++ b/packages/npm-cli/src/lib/config.js
@@ -1,6 +1,7 @@
 import { cwd } from 'node:process';
 import { resolve, dirname } from 'node:path';
 import { statSync, existsSync, readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 
 const PACKAGE_NAME = '@wunderio/node-agents';
 const DEFAULT_CONTAINER_NAME_PREFIX = 'agents';
@@ -8,8 +9,6 @@ const DEFAULT_CONTAINER_NAME_PREFIX = 'agents';
 export function resolveProjectRoot() {
   return cwd();
 }
-
-import { createHash } from 'node:crypto';
 
 export function getProjectName(projectRoot) {
   const packageJsonPath = resolve(projectRoot, 'package.json');

--- a/packages/npm-cli/src/lib/config.js
+++ b/packages/npm-cli/src/lib/config.js
@@ -32,7 +32,6 @@ export function getProjectName(projectRoot) {
   }
   return 'node-agents';
 }
-}
 
 export function getDevcontainerConfigPath(projectRoot) {
   return resolve(projectRoot, '.devcontainer', 'devcontainer.json');

--- a/packages/npm-cli/src/lib/config.js
+++ b/packages/npm-cli/src/lib/config.js
@@ -1,0 +1,41 @@
+import { cwd } from 'node:process';
+import { resolve, dirname } from 'node:path';
+import { statSync, existsSync, readFileSync } from 'node:fs';
+
+const PACKAGE_NAME = '@wunderio/node-agents';
+const DEFAULT_CONTAINER_NAME_PREFIX = 'agents';
+
+export function resolveProjectRoot() {
+  return cwd();
+}
+
+export function getProjectName(projectRoot) {
+  const packageJsonPath = resolve(projectRoot, 'package.json');
+  if (existsSync(packageJsonPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+      if (pkg.name) {
+        return String(pkg.name).replace(/^@[^/]+\//, '').replace(/[^a-zA-Z0-9_-]/g, '-');
+      }
+    } catch {
+      // fall through
+    }
+  }
+  return 'node-agents';
+}
+
+export function getDevcontainerConfigPath(projectRoot) {
+  return resolve(projectRoot, '.devcontainer', 'devcontainer.json');
+}
+
+export function getToolsConfigPath(projectRoot) {
+  return resolve(projectRoot, '.agents', 'tools-config');
+}
+
+export function getContainerName(projectName) {
+  return `${projectName}-${DEFAULT_CONTAINER_NAME_PREFIX}`;
+}
+
+export function getImageName(projectName) {
+  return `${projectName}-agents:latest`;
+}

--- a/packages/npm-cli/src/lib/container.js
+++ b/packages/npm-cli/src/lib/container.js
@@ -1,0 +1,95 @@
+/**
+ * Helpers for invoking the devcontainer CLI.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveNodeVersion } from '@wunderio/agents-core';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, '../..');
+
+export function ensureDevcontainerCli() {
+  return new Promise((resolve, reject) => {
+    const check = spawn('devcontainer', ['--version'], { stdio: 'ignore' });
+    check.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        console.log('⚠️  devcontainer CLI not found. Installing globally...');
+        const install = spawn('npm', ['install', '-g', '@devcontainers/cli'], {
+          stdio: 'inherit'
+        });
+        install.on('close', (installCode) => {
+          if (installCode === 0) {
+            resolve();
+          } else {
+            reject(new Error(`Failed to install devcontainer CLI (exit ${installCode})`));
+          }
+        });
+        install.on('error', reject);
+      }
+    });
+    check.on('error', () => {
+      console.log('⚠️  devcontainer CLI not found. Installing globally...');
+      const install = spawn('npm', ['install', '-g', '@devcontainers/cli'], {
+        stdio: 'inherit'
+      });
+      install.on('close', (installCode) => {
+        if (installCode === 0) {
+          resolve();
+        } else {
+          reject(new Error(`Failed to install devcontainer CLI (exit ${installCode})`));
+        }
+      });
+      install.on('error', reject);
+    });
+  });
+}
+
+export async function execDevcontainer(args, options = {}) {
+  await ensureDevcontainerCli();
+  const { spawn } = await import('node:child_process');
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('devcontainer', args, {
+      stdio: 'inherit',
+      ...options,
+      env: { ...process.env, ...options.env }
+    });
+
+    child.on('close', (code) => {
+      resolve(code ?? 0);
+    });
+
+    child.on('error', reject);
+  });
+}
+
+function readTemplate(name) {
+  const templateUrl = import.meta.resolve(`@wunderio/agents-core/templates/${name}`);
+  return readFileSync(fileURLToPath(templateUrl), 'utf8');
+}
+
+function renderTemplate(template, vars) {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => vars[key] ?? '');
+}
+
+export function writeDevcontainerConfig({ projectRoot, projectName, nodeVersion }) {
+  const template = readTemplate('devcontainer.json.node.hbs');
+  const rendered = renderTemplate(template, {
+    projectName,
+    nodeVersion
+  });
+
+  const devcontainerDir = resolve(projectRoot, '.devcontainer');
+  mkdirSync(devcontainerDir, { recursive: true });
+
+  const configPath = resolve(devcontainerDir, 'devcontainer.json');
+  writeFileSync(configPath, rendered, 'utf8');
+  return configPath;
+}
+
+export { resolveNodeVersion };

--- a/packages/npm-cli/src/lib/container.js
+++ b/packages/npm-cli/src/lib/container.js
@@ -68,6 +68,49 @@ export async function execDevcontainer(args, options = {}) {
   });
 }
 
+/**
+ * Runs `devcontainer up` and returns the parsed result, including the
+ * container-side workspace folder (e.g. /workspaces/<project>). The devcontainer
+ * CLI decides this path (it is NOT necessarily /workspace), so callers must use
+ * the reported value instead of hardcoding a mount path.
+ */
+export async function devcontainerUp(projectRoot) {
+  await ensureDevcontainerCli();
+  const { spawn } = await import('node:child_process');
+
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(
+      'devcontainer',
+      ['up', '--workspace-folder', projectRoot],
+      { stdio: ['inherit', 'pipe', 'inherit'], env: { ...process.env } }
+    );
+
+    let stdout = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+      process.stdout.write(chunk);
+    });
+
+    child.on('close', (code) => {
+      let remoteWorkspaceFolder;
+      const line = stdout
+        .split('\n')
+        .reverse()
+        .find((l) => l.includes('"remoteWorkspaceFolder"'));
+      if (line) {
+        try {
+          remoteWorkspaceFolder = JSON.parse(line).remoteWorkspaceFolder;
+        } catch {
+          // ignore parse errors; caller falls back to a default
+        }
+      }
+      resolvePromise({ code: code ?? 0, remoteWorkspaceFolder });
+    });
+
+    child.on('error', reject);
+  });
+}
+
 function readTemplate(name) {
   const templateUrl = import.meta.resolve(`@wunderio/agents-core/templates/${name}`);
   return readFileSync(fileURLToPath(templateUrl), 'utf8');

--- a/packages/npm-cli/src/lib/container.test.js
+++ b/packages/npm-cli/src/lib/container.test.js
@@ -1,0 +1,31 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeDevcontainerConfig } from './container.js';
+
+describe('writeDevcontainerConfig', () => {
+  it('writes a rendered devcontainer.json with the correct node version and project name', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agents-cli-test-'));
+    try {
+      const configPath = writeDevcontainerConfig({
+        projectRoot: dir,
+        projectName: 'my-node-app',
+        nodeVersion: '20'
+      });
+
+      assert.equal(configPath, join(dir, '.devcontainer', 'devcontainer.json'));
+      assert.equal(existsSync(configPath), true);
+
+      const config = JSON.parse(readFileSync(configPath, 'utf8'));
+      assert.equal(config.name, 'Agents: my-node-app');
+      assert.equal(config.features['ghcr.io/devcontainers/features/node:1'].version, '20');
+      assert.equal(config.remoteEnv.SSH_AUTH_SOCK, '');
+      assert.ok(Array.isArray(config.mounts));
+      assert.ok(config.mounts.some((m) => m.includes('copilot-managed-config.json')));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/npm-cli/src/lib/mcp.js
+++ b/packages/npm-cli/src/lib/mcp.js
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+function readCoreTemplate(name) {
+  const templateUrl = import.meta.resolve(`@wunderio/agents-core/templates/${name}`);
+  return readFileSync(fileURLToPath(templateUrl), 'utf8');
+}
+
+function render(template, vars) {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => vars[key] ?? '');
+}
+
+function npmView(packageName, fallback) {
+  return new Promise((resolve) => {
+    const child = spawn('npm', ['view', packageName, 'version'], {
+      stdio: ['ignore', 'pipe', 'ignore']
+    });
+    let output = '';
+    child.stdout.on('data', (data) => {
+      output += data.toString();
+    });
+    child.on('close', (code) => {
+      const version = code === 0 ? output.trim() : fallback;
+      resolve(version || fallback);
+    });
+    child.on('error', () => resolve(fallback));
+  });
+}
+
+export async function getPackageVersions() {
+  const [wdrmcpVersion, supergatewayVersion] = await Promise.all([
+    npmView('@wunderio/wdrmcp', '0.1.17'),
+    npmView('supergateway', '3.4.3')
+  ]);
+  return { wdrmcpVersion, supergatewayVersion };
+}
+
+export function generateCliMcpConfig({ projectName, toolsConfigPath, wdrmcpVersion, supergatewayVersion }) {
+  const template = readCoreTemplate('mcp-config.json.hbs');
+  return render(template, {
+    projectName,
+    toolsConfigPath,
+    wdrmcpVersion,
+    supergatewayVersion,
+    wqsApiKey: '\\${WQS_MCP_API_KEY}'
+  });
+}
+
+export function generateVscodeMcpConfig({ projectName, toolsConfigPath, wdrmcpVersion, supergatewayVersion }) {
+  const template = readCoreTemplate('vscode-mcp.json.hbs');
+  return render(template, {
+    projectName,
+    toolsConfigPath,
+    wdrmcpVersion,
+    supergatewayVersion,
+    wqsApiKey: '${WQS_MCP_API_KEY}'
+  });
+}

--- a/packages/npm-cli/src/lib/mcp.js
+++ b/packages/npm-cli/src/lib/mcp.js
@@ -43,7 +43,7 @@ export function generateCliMcpConfig({ projectName, toolsConfigPath, wdrmcpVersi
     toolsConfigPath,
     wdrmcpVersion,
     supergatewayVersion,
-    wqsApiKey: '\\${WQS_MCP_API_KEY}'
+    wqsApiKey: '${WQS_MCP_API_KEY}'
   });
 }
 

--- a/scripts/sync-core-to-ddev.js
+++ b/scripts/sync-core-to-ddev.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Build-time sync: copy shared core templates into the DDEV add-on root files.
+ *
+ * Run via: npm run sync-core-to-ddev
+ */
+
+import { readFileSync, writeFileSync, copyFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const coreTemplates = resolve(root, 'packages', 'core', 'templates');
+
+function readTemplate(name) {
+  return readFileSync(resolve(coreTemplates, name), 'utf8');
+}
+
+function writeJson(path, content) {
+  writeFileSync(path, JSON.stringify(content, null, 2) + '\n', 'utf8');
+}
+
+function syncManagedConfig() {
+  const source = resolve(coreTemplates, 'copilot-managed-config.json');
+  const dest = resolve(root, 'copilot-managed-config.json');
+  copyFileSync(source, dest);
+  console.log('✅ Synced copilot-managed-config.json');
+}
+
+function syncDevcontainerBuild() {
+  const template = readTemplate('devcontainer.build.json.php.hbs');
+  writeFileSync(resolve(root, '.devcontainer', 'devcontainer.build.json'), template, 'utf8');
+  console.log('✅ Synced .devcontainer/devcontainer.build.json');
+}
+
+function syncDevcontainerAttach() {
+  const template = readTemplate('devcontainer.json.php.hbs');
+  writeFileSync(resolve(root, '.devcontainer', 'devcontainer.json'), template, 'utf8');
+  console.log('✅ Synced .devcontainer/devcontainer.json');
+}
+
+syncManagedConfig();
+syncDevcontainerBuild();
+syncDevcontainerAttach();
+
+console.log('\nDDEV add-on files regenerated from packages/core/templates.');
+console.log('Review the diff before committing.');


### PR DESCRIPTION
This pull request introduces a major refactor to support both DDEV-based and standalone Node.js (npm) agent environments in a unified monorepo. It adds new npm packages, shared core templates and utilities, and updates documentation and CI/CD workflows to reflect the new structure and features.

**Monorepo and npm Workspaces:**

* Converted the repository to an npm workspaces monorepo with a root `package.json`, organizing code into `packages/core` (shared logic and templates) and `packages/npm-cli` (standalone CLI for Node.js projects). [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R1-R22) [[2]](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7R1-R17)

**New Features for Node.js Projects:**

* Added the `@wunderio/node-agents` npm package for non-DDEV Node.js projects and the shared `@wunderio/agents-core` package with devcontainer templates, managed security config, MCP config templates, version resolution, and Copilot invocation helpers. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R30) [[2]](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7R1-R17) [[3]](diffhunk://#diff-25426a917b53575c0f0efc5674ee70c4d2c8671f9ade4f9d994db43c9552302bR1-R26)
* Implemented lockfile-based package manager detection and CLI commands (`agents build`, `agents set-up`, `agents copilot`, etc.) for agent operations in Node.js environments. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R152-R202)
* Documented the new npm-based workflow and provided setup instructions in the `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R152-R202)

**Shared Core Functionality and Templates:**

* Added core utilities for Node.js version resolution (`resolveNodeVersion`), Copilot CLI invocation (`invokeCopilot`), and a suite of devcontainer and managed config templates for both PHP/DDEV and Node.js environments. [[1]](diffhunk://#diff-25426a917b53575c0f0efc5674ee70c4d2c8671f9ade4f9d994db43c9552302bR1-R26) [[2]](diffhunk://#diff-71f4cd516290108cddd42daea897c7351684f8caf05d7242f0a30c67aba309f2R1-R51) [[3]](diffhunk://#diff-48a0b4587d1824515eb5b901f38727f3d0e8992682d8760e55457efd34bfd03eR1-R43) [[4]](diffhunk://#diff-7620ec631f5fc40bf4a60659c0e67892f13af616be4d36c89c074d3bea618d62R1-R46) [[5]](diffhunk://#diff-c3d2d959a807c7be92b8f1b8fd823518a7a194148d753b79b3170ba5e2b992a0R1-R33) [[6]](diffhunk://#diff-629318d4d613213a5add37017cf35a8d2ef1ec00c070c57d8fc2bbf79ab49342R1-R15) [[7]](diffhunk://#diff-44311c106b7693d6e46e4b4d97c33443cd34c2d7d083a010abbfe582bed6878fR1-R19) [[8]](diffhunk://#diff-bd983f52ff52e34c047c859c3597365affe79367401baf9c681c0131695e3f5bR1-R32) [[9]](diffhunk://#diff-336a68e29c37811c176788e4fd86117f26167dff0df4d07bc669a73b6d380c31R1-R55) [[10]](diffhunk://#diff-28964e0cf305c0c9612d0ebf897230c764b5e697a15e6217b0a2a7a10ab3b2deR1-R70)

**CI/CD and Automation:**

* Added GitHub Actions workflows for CI (testing, sync, and CLI help verification) and npm package publishing, ensuring the new structure is automatically tested and released. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R31) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R1-R32)

**Developer Experience:**

* Added recommended VS Code extensions and workspace settings for markdown linting and MCP integration, improving the out-of-the-box developer experience. [[1]](diffhunk://#diff-54809ad9e00c7266411a7a8565344624a756574ed960a60b21d97b234f37ce1bR1-R13) [[2]](diffhunk://#diff-887c42984f174f5571919b0aeef09a0f3703242990d62f190b5e7852000eae24R1-R24) [[3]](diffhunk://#diff-63d23bdc16245570f2941dc1a9eedcc70d7c65c799c59b46fdfd4d3cf1206c9dR1-R7)

These changes lay the groundwork for a unified, secure, and flexible agentic AI environment for both PHP/DDEV and Node.js projects, with a strong focus on code reuse, automation, and developer ergonomics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `@wunderio/node-agents` npm package for Node.js/npm projects.
  * Added CLI commands for setup, building, starting/stopping containers, Copilot, npm, npx, and command execution.
  * Added MCP tools for dependency installation, scripts, testing, linting, builds, npx, and logs.
  * Added automatic Node.js version detection and devcontainer configuration.
* **Documentation**
  * Added Node.js/npm installation, usage, security, and troubleshooting guidance.
* **Chores**
  * Added automated testing and npm package publishing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# How to test

These steps let you build the npm packages as tarballs and install them into a
**separate local project**, exactly as an end user would consume them from the
npm registry — without publishing anything.

There are two packages in this monorepo:

| Package | Tarball |
|---|---|
| `@wunderio/agents-core` | `wunderio-agents-core-<version>.tgz` |
| `@wunderio/node-agents` (the `agents` CLI) | `wunderio-node-agents-<version>.tgz` |

`@wunderio/node-agents` depends on `@wunderio/agents-core`. Because the core
package is **not published**, you must install **both** tarballs together into
the test project (see step 3), otherwise npm will try to fetch
`@wunderio/agents-core` from the registry and fail.

---

## Prerequisites

- Node.js 20+ and npm on the host
- Docker running on the host (the CLI drives a devcontainer)
- A GitHub token with **Copilot Requests: Read-only**:
  ```bash
  export DDEV_AGENTS_GH_TOKEN=your_token_here
  ```
- (Optional) Wunder Quality System key:
  ```bash
  export WQS_MCP_API_KEY=your_key_here
  ```

---

## 1. Build the tarballs

From the monorepo root (`/workspace`):

```bash
npm pack \
  --workspace @wunderio/agents-core \
  --workspace @wunderio/node-agents \
  --pack-destination agents-tarballs
```

This writes (or overwrites) both tarballs into `agents-tarballs/`:

```bash
ls -la agents-tarballs/
# wunderio-agents-core-1.0.0.tgz
# wunderio-node-agents-1.0.0.tgz
```

> Tip: to be sure a fix is actually packed, inspect a file inside the tarball
> without extracting, e.g.:
> ```bash
> tar -xzOf agents-tarballs/wunderio-node-agents-1.0.0.tgz \
>   package/src/commands/set-up.js | head
> ```

---

## 2. Create a throwaway test project

Use any directory **outside** this repo so you exercise a real, separate
project:

```bash
mkdir -p /tmp/agents-test && cd /tmp/agents-test
npm init -y
# Optional: pin the Node version the devcontainer should use
echo "20" > .nvmrc
```

Record the absolute path to the tarballs for the next step:

```bash
TARBALLS=/workspace/agents-tarballs
```

---

## 3. Install both tarballs into the test project

Install **core and cli together in a single command** so npm resolves the
local `@wunderio/agents-core` dependency from the tarball instead of the
registry:

```bash
cd /tmp/agents-test
npm install --save-dev \
  "$TARBALLS/wunderio-agents-core-1.0.0.tgz" \
  "$TARBALLS/wunderio-node-agents-1.0.0.tgz"
```

Verify the `agents` binary is available:

```bash
npx agents --help
```

You should see the usage listing (`set-up`, `copilot`, `start`, `stop`, ...).

---

## 4. Run setup

```bash
cd /tmp/agents-test
npx agents set-up
```

Expected output ends with:

```
✅ Symlinked ~/.copilot to /workspaces/agents-test/.copilot
✅ Wrote Copilot CLI MCP config
✅ Wrote VS Code MCP config
✅ Setup complete. Run `agents copilot` or attach VS Code to the devcontainer.
```

---

## 5. Verify the generated files

On the host:

```bash
cd /tmp/agents-test
cat .devcontainer/devcontainer.json          # rendered from the node template
cat .devcontainer/copilot-managed-config.json # security deny-lists
ls .agents/tools-config                        # copied tool configs
```

Inside the container (paths are anchored to the devcontainer workspace folder,
typically `/workspaces/<project>`):

```bash
npx agents exec -- bash -c 'readlink ~/.copilot'
# -> /workspaces/agents-test/.copilot

npx agents exec -- cat ~/.copilot/mcp-config.json
```

Check the MCP config is correct:

- `wdrmcp` / `supergateway` args are **unpinned** (`@wunderio/wdrmcp`,
  `supergateway`) so the registry fingerprints match.
- The WQS bearer is exactly `${WQS_MCP_API_KEY}` — **no** leading backslash.

---

## 6. Verify MCP connections in Copilot

```bash
cd /tmp/agents-test
npx agents copilot
```

Then inside Copilot, list MCP servers (e.g. `/mcp`). Both `wdrmcp` and
`wunder-quality-system` should show as **connected**. If a server is blocked,
re-check step 5 — a pinned version in the args or a stray backslash in the
bearer token are the usual causes.

---

## 7. Iterate (rebuild → reinstall loop)

After changing code in `packages/`, rebuild and reinstall:

```bash
# 1. rebuild tarballs (monorepo root)
cd /workspace
npm pack --workspace @wunderio/agents-core --workspace @wunderio/node-agents \
  --pack-destination agents-tarballs

# 2. reinstall into the test project (force fresh copy)
cd /tmp/agents-test
rm -rf node_modules/@wunderio package-lock.json
npm install --save-dev \
  /workspace/agents-tarballs/wunderio-agents-core-1.0.0.tgz \
  /workspace/agents-tarballs/wunderio-node-agents-1.0.0.tgz

# 3. re-run
npx agents set-up
```

> npm caches tarballs by name+version. If the version number did not change,
> clearing `node_modules/@wunderio` (as above) guarantees the new build is used.
> Alternatively bump the `version` in both `package.json` files before packing.

---

## 8. Run the unit tests (optional)

```bash
cd /workspace
npm test --workspaces
```

---

## 9. Cleanup

```bash
rm -rf /tmp/agents-test
npx agents stop   # if a container is still running (run from the test project)
```
